### PR TITLE
Bugfix to Start Stop Import Scripts

### DIFF
--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.0.2/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.0.2/mwaa_import_data.py
@@ -46,10 +46,10 @@ dag_hash, creating_job_id) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
 
 TASK_INSTANCE_IMPORT = "COPY task_instance(task_id, dag_id, execution_date, start_date, end_date, \
 duration, state, try_number, hostname, unixname, job_id, pool, \
-queue, priority_weight, operator, queued_dttm, pid, max_tries, executor_config,\
+queue, priority_weight, operator, queued_dttm, pid, max_tries, executor_config, \
 pool_slots, queued_by_job_id, external_executor_id) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
 
-TASK_FAIL_IMPORT = "COPY task_fail(task_id, dag_id, execution_date\
+TASK_FAIL_IMPORT = "COPY task_fail(task_id, dag_id, execution_date, \
  start_date, end_date, duration) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
 
 
@@ -74,7 +74,7 @@ TOPTABLES_TO_IMPORT = [
 
 ]
 
-    
+
 # pause all dags before starting export
 def pause_dags():
     session = settings.Session()
@@ -159,7 +159,7 @@ def importConnection(**context):
     session.commit()
     session.close()
 
-    
+
 
 
 def load_data(**context):
@@ -277,5 +277,6 @@ with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=def
         python_callable=notify_success,
         provide_context=True
     )
+    taskfail_dagrun >> notify_success_t
     activate_dags_t >> notify_success_t
 

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.2.2/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.2.2/mwaa_import_data.py
@@ -278,5 +278,6 @@ with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=def
         python_callable=notify_success,
         provide_context=True
     )
+    taskfail_dagrun >> notify_success_t
     activate_dags_t >> notify_success_t
 

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.4.3/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.4.3/mwaa_import_data.py
@@ -316,5 +316,5 @@ with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=def
         provide_context=True
     )
     activate_dags_t >> notify_success_t
-
+    taskfail_dagrun >> notify_success_t
     load_ds_dagrun >> notify_success_t

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.5.1/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.5.1/mwaa_import_data.py
@@ -315,5 +315,5 @@ with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=def
         provide_context=True
     )
     activate_dags_t >> notify_success_t
-
+    taskfail_dagrun >> notify_success_t
     load_ds_dagrun >> notify_success_t


### PR DESCRIPTION
This PR contributes the following:
- Fixes a missing comma in the SQL script for 2.0.2
- Fixes the task dependencies to make the `notify_success` be the final downstream task for all sub tasks in the import dags scripts (all versions) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
