### PR TITLE
chore: upgrade CodeArtifact use case from CDK version 1 to 2

### DIFF
--- a/usecases/mwaa-with-codeartifact/app.py
+++ b/usecases/mwaa-with-codeartifact/app.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import os
 
-from aws_cdk import core as cdk
-from aws_cdk import core
+import aws_cdk as cdk
 
 from infra.vpc_stack import VpcStack
 from infra.codeartifact_stack import CodeArtifactStack
@@ -11,8 +10,8 @@ from infra.s3_stack import S3Stack
 from infra.mwaa_stack import MwaaStack
 
 
-app = core.App()
-env = core.Environment(region=os.environ.get("AWS_REGION"))
+app = cdk.App()
+env = cdk.Environment(region=os.environ.get("AWS_REGION"))
 
 vpc = VpcStack(app, "VpcStack", env=env)
 ca = CodeArtifactStack(app, "CodeArtifactStack", env=env)

--- a/usecases/mwaa-with-codeartifact/cdk.json
+++ b/usecases/mwaa-with-codeartifact/cdk.json
@@ -2,13 +2,11 @@
   "app": "python3 app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true",
     "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
     "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
     "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-efs:defaultEncryptionAtRest": true

--- a/usecases/mwaa-with-codeartifact/infra/codeartifact_stack.py
+++ b/usecases/mwaa-with-codeartifact/infra/codeartifact_stack.py
@@ -1,9 +1,10 @@
-from aws_cdk import core
+from aws_cdk import Resource, Stack
 import aws_cdk.aws_codeartifact as codeartifact
+from constructs import Construct
 
 
-class CodeArtifactStack(core.Stack):
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+class CodeArtifactStack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         ca_domain = codeartifact.CfnDomain(
@@ -20,5 +21,5 @@ class CodeArtifactStack(core.Stack):
         self._repo.add_depends_on(ca_domain)
 
     @property
-    def repo(self) -> core.Resource:
+    def repo(self) -> Resource:
         return self._repo

--- a/usecases/mwaa-with-codeartifact/infra/codeartifact_stack.py
+++ b/usecases/mwaa-with-codeartifact/infra/codeartifact_stack.py
@@ -18,7 +18,7 @@ class CodeArtifactStack(Stack):
             external_connections=["public:pypi"],
             description="This is demo repo for MWAA.",
         )
-        self._repo.add_depends_on(ca_domain)
+        self._repo.add_dependency(ca_domain)
 
     @property
     def repo(self) -> Resource:

--- a/usecases/mwaa-with-codeartifact/infra/mwaa_stack.py
+++ b/usecases/mwaa-with-codeartifact/infra/mwaa_stack.py
@@ -1,13 +1,14 @@
 import os
 
-from aws_cdk import aws_mwaa as mwaa, aws_iam as iam, core
+from aws_cdk import aws_mwaa as mwaa, aws_iam as iam, CfnJson, Stack
+from constructs import Construct
 from infra.s3_stack import S3Stack
 from infra.vpc_stack import VpcStack
 
 
-class MwaaStack(core.Stack):
+class MwaaStack(Stack):
     def __init__(
-        self, scope: core.Construct, id: str, vpc: VpcStack, s3: S3Stack, **kwargs
+        self, scope: Construct, id: str, vpc: VpcStack, s3: S3Stack, **kwargs
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
@@ -94,7 +95,7 @@ class MwaaStack(core.Stack):
                 effect=iam.Effect.ALLOW,
             )
         )
-        string_like = core.CfnJson(
+        string_like = CfnJson(
             self,
             "ConditionJson",
             value={f"kms:ViaService": f"sqs.{self.region}.amazonaws.com"},

--- a/usecases/mwaa-with-codeartifact/infra/s3_stack.py
+++ b/usecases/mwaa-with-codeartifact/infra/s3_stack.py
@@ -1,12 +1,13 @@
 import os
 import secrets
 
-from aws_cdk import aws_s3 as s3, core
+from aws_cdk import aws_s3 as s3, RemovalPolicy, Resource, Stack
 from aws_cdk import aws_s3_deployment as s3_deploy
+from constructs import Construct
 
 
-class S3Stack(core.Stack):
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+class S3Stack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         rand_int = secrets.randbelow(1000001)
@@ -15,7 +16,7 @@ class S3Stack(core.Stack):
             "mwaa-ca-bucket",
             bucket_name=os.environ.get("BUCKET_NAME", f"mwaa-ca-{rand_int}"),
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
-            removal_policy=core.RemovalPolicy.DESTROY,
+            removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,
             versioned=True,
         )
@@ -30,5 +31,5 @@ class S3Stack(core.Stack):
         )
 
     @property
-    def instance(self) -> core.Resource:
+    def instance(self) -> Resource:
         return self._instance

--- a/usecases/mwaa-with-codeartifact/infra/vpc_stack.py
+++ b/usecases/mwaa-with-codeartifact/infra/vpc_stack.py
@@ -1,9 +1,10 @@
-from aws_cdk import core, aws_ec2 as ec2
+from aws_cdk import aws_ec2 as ec2, CfnOutput, Resource, Stack, Tags
+from constructs import Construct
 from typing import List
 
 
-class VpcStack(core.Stack):
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+class VpcStack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         self._instance = ec2.Vpc(
@@ -19,10 +20,10 @@ class VpcStack(core.Stack):
         self.create_security_groups()
         self.create_endpoints()
         self.tag_subnets()
-        core.CfnOutput(self, "Output", value=self._instance.vpc_id)
+        CfnOutput(self, "Output", value=self._instance.vpc_id)
 
     @property
-    def instance(self) -> core.Resource:
+    def instance(self) -> Resource:
         return self._instance
 
     @property
@@ -89,5 +90,5 @@ class VpcStack(core.Stack):
     def tag_subnets(self) -> None:
         selection = self.instance.select_subnets(subnet_type=ec2.SubnetType.ISOLATED)
         for subnet in selection.subnets:
-            core.Tags.of(subnet).add("Name", f"mwaa-private-{subnet.availability_zone}")
-        core.Tags.of(self.instance).add("Name", "private-mwaa-vpc")
+            Tags.of(subnet).add("Name", f"mwaa-private-{subnet.availability_zone}")
+        Tags.of(self.instance).add("Name", "private-mwaa-vpc")

--- a/usecases/mwaa-with-codeartifact/requirements.txt
+++ b/usecases/mwaa-with-codeartifact/requirements.txt
@@ -1,9 +1,2 @@
-aws-cdk.core==1.102.0
-aws-cdk.aws_ec2==1.102.0
-aws-cdk.aws_codeartifact==1.102.0
-aws-cdk.aws_mwaa==1.102.0
-aws-cdk.aws_s3_deployment==1.102.0
-aws-cdk.aws_events==1.102.0
-aws-cdk.aws_lambda==1.102.0
-aws-cdk.aws_events_targets==1.102.0
-aws-cdk.aws_iam==1.102.0
+aws-cdk-lib>=2.16.0,<3.0.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
*Description of changes:*

This PR upgrades the `mwaa-with-codeartifact` use case from CDK version 1 to 2.

Here's a problem that solves.
- [According to AWS](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html), "Support for CDK v1 will end entirely on June 1, 2023."
- The `mwaa-with-codeartifact` use case used CDK v1.

My focus is on the `mwaa-with-codeartifact` case because it helped me get started with MWAA. This PR might serve as a guide for updating the other use cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
