### PR TITLE
Bump JQuery from 3.4.1 to 3.7.0 in error-page template.html

### DIFF
--- a/usecases/mwaa-public-webserver-custom-domain/src/lambda-edge/shared/error-page/template.html
+++ b/usecases/mwaa-public-webserver-custom-domain/src/lambda-edge/shared/error-page/template.html
@@ -60,8 +60,8 @@
       </div>
     </div>
     <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
+      src="https://code.jquery.com/jquery-3.7.0.slim.min.js"
+      integrity="sha256-tG5mcZUtJsZvyKAxYLVXrmjKBVLd6VpVccqz/r4ypFE="
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
*Description of changes:*

This PR bumps up the JQuery version referenced in usecases/mwaa-public-webserver-custom-domain/src/lambda-edge/shared/error-age to patch a security issue. JQuery versions prior to 3.5.0 are vulnerable to XSS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
