### PR TITLE
add lambda:TagResource to deployment action

### DIFF
--- a/usecases/mwaa-public-webserver-custom-domain/template.yaml
+++ b/usecases/mwaa-public-webserver-custom-domain/template.yaml
@@ -447,6 +447,7 @@ Resources:
           - lambda:DeleteFunction
           - lambda:UpdateFunctionCode
           - lambda:UpdateFunctionConfiguration
+          - lambda:TagResource
           Resource:
           - Fn::Sub: arn:${AWS::Partition}:lambda:us-east-1:${AWS::AccountId}:function:*-CheckAuthHandler-*
           - Fn::Sub: arn:${AWS::Partition}:lambda:us-east-1:${AWS::AccountId}:function:*-ParseAuthHandler-*


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In the `mwaa-public-webserver-custom-domain` use case, the following permission error occurs when executing `sam deploy`.
```
Resource handler returned message: "User: arn:aws:sts::xxxx:assumed-role/public-mwaa-custom-domain-UsEast1DeploymentHandlerR-xxxx/public-mwaa-custom-domain-UsEast1DeploymentHandler-xxxx is not authorized to perform: lambda:TagResource on resource: arn:aws:lambda:us-east-1:xxxx:function:public-mwaa-custom-domain-ParseAuthHandler-xxxx because no identity-based policy allows the lambda:TagResource action (Service: Lambda, Status Code: 403, Request ID: xxxx)" (RequestToken: xxxx, HandlerErrorCode: AccessDenied)
```
This pull request resolves the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
