### PR TITLE
upgrade nodejs to 18 and aws-sdk to v3

### DIFF
--- a/usecases/mwaa-public-webserver-custom-domain/package.json
+++ b/usecases/mwaa-public-webserver-custom-domain/package.json
@@ -20,7 +20,7 @@
     "@types/aws-lambda": "^8.10.77",
     "@types/cookie": "^0.4.0",
     "@types/fs-extra": "^9.0.11",
-    "@types/node": "^15.12.5",
+    "@types/node": "^20.11.17",
     "aws-sdk": "^2.935.0",
     "html-loader": "^2.1.2",
     "prettier": "^2.3.2",
@@ -32,7 +32,11 @@
     "webpack-cli": "^4.7.2"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudformation": "^3.529.1",
+    "@aws-sdk/client-cognito-identity-provider": "^3.530.0",
+    "@aws-sdk/client-lambda": "^3.529.1",
     "@aws-sdk/client-mwaa": "^3.49.0",
+    "@aws-sdk/client-s3": "^3.529.1",
     "adm-zip": "^0.5.5",
     "aws-jwt-verify": "^1.0.2",
     "cookie": "^0.4.1"

--- a/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/client-secret-retrieval/index.ts
+++ b/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/client-secret-retrieval/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import { CloudFormationCustomResourceHandler } from "aws-lambda";
-import CognitoIdentityServiceProvider from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { CognitoIdentityProvider, DescribeUserPoolClientCommandInput } from "@aws-sdk/client-cognito-identity-provider";
 import { sendCfnResponse, Status } from "./cfn-response";
 
 async function retrieveClientSecret(
@@ -17,17 +17,16 @@ async function retrieveClientSecret(
   }
   const userPoolId = userPoolArn.split("/")[1];
   const userPoolRegion = userPoolArn.split(":")[3];
-  const cognitoClient = new CognitoIdentityServiceProvider({
+  const cognitoClient = new CognitoIdentityProvider({
     region: userPoolRegion,
   });
-  const input: CognitoIdentityServiceProvider.Types.DescribeUserPoolClientRequest =
+  const input: DescribeUserPoolClientCommandInput =
     {
       UserPoolId: userPoolId,
       ClientId: clientId,
     };
   const { UserPoolClient } = await cognitoClient
-    .describeUserPoolClient(input)
-    .promise();
+    .describeUserPoolClient(input);
   if (!UserPoolClient?.ClientSecret) {
     throw new Error(
       `User Pool client ${clientId} is not set up with a client secret`

--- a/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/lambda-code-update/index.ts
+++ b/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/lambda-code-update/index.ts
@@ -6,7 +6,7 @@ import {
   CloudFormationCustomResourceDeleteEvent,
   CloudFormationCustomResourceUpdateEvent,
 } from "aws-lambda";
-import Lambda from "aws-sdk/clients/lambda";
+import { Lambda } from "@aws-sdk/client-lambda";
 import Zip from "adm-zip";
 import { writeFileSync, mkdtempSync } from "fs";
 import { resolve } from "path";
@@ -27,15 +27,16 @@ async function updateLambdaCode(
     `Adding configuration to Lambda function ${lambdaFunction}:\n${stringifiedConfig}`
   );
   const region = lambdaFunction.split(":")[3];
-  const lambdaClient = new Lambda({ region });
+  const lambdaClient = new Lambda({
+    region,
+  });
   // Parse the JSON to ensure it's validity (and avoid ugly errors at runtime)
   const config = JSON.parse(stringifiedConfig);
   // Fetch and extract Lambda zip contents to temporary folder, add configuration.json, and rezip
   const { Code } = await lambdaClient
     .getFunction({
       FunctionName: lambdaFunction,
-    })
-    .promise();
+    });
   const data = await fetch(Code!.Location!);
   const lambdaZip = new Zip(data);
   console.log(
@@ -61,8 +62,7 @@ async function updateLambdaCode(
       FunctionName: lambdaFunction,
       ZipFile: newLambdaZip.toBuffer(),
       Publish: true,
-    })
-    .promise();
+    });
   console.log({ CodeSha256, Version, FunctionArn });
   return {
     physicalResourceId: lambdaFunction,

--- a/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/user-pool-client/index.ts
+++ b/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/user-pool-client/index.ts
@@ -13,7 +13,11 @@ import {
   CloudFormationCustomResourceHandler,
   CloudFormationCustomResourceUpdateEvent,
 } from "aws-lambda";
-import CognitoIdentityServiceProvider from "aws-sdk/clients/cognitoidentityserviceprovider";
+import {
+  CognitoIdentityProvider,
+  UpdateUserPoolClientCommandInput,
+  UserPoolClientType,
+} from "@aws-sdk/client-cognito-identity-provider";
 import { sendCfnResponse, Status } from "./cfn-response";
 
 const CUSTOM_RESOURCE_CURRENT_VERSION_NAME = "UpdatedUserPoolClientV2";
@@ -22,7 +26,7 @@ const SENTINEL_DOMAIN = "example.com";
 async function getUserPoolClient(props: Props) {
   const userPoolId = props.UserPoolArn.split("/")[1];
   const userPoolRegion = props.UserPoolArn.split(":")[3];
-  const cognitoClient = new CognitoIdentityServiceProvider({
+  const cognitoClient = new CognitoIdentityProvider({
     region: userPoolRegion,
   });
   const input = {
@@ -31,8 +35,7 @@ async function getUserPoolClient(props: Props) {
   };
   console.debug("Describing User Pool Client", JSON.stringify(input, null, 4));
   const { UserPoolClient } = await cognitoClient
-    .describeUserPoolClient(input)
-    .promise();
+    .describeUserPoolClient(input);
   if (!UserPoolClient) {
     throw new Error("User Pool Client not found!");
   }
@@ -43,11 +46,11 @@ async function updateUserPoolClient(
   props: Props,
   redirectUrisSignIn: string[],
   redirectUrisSignOut: string[],
-  existingUserPoolClient: CognitoIdentityServiceProvider.UserPoolClientType
+  existingUserPoolClient: UserPoolClientType
 ) {
   const userPoolId = props.UserPoolArn.split("/")[1];
   const userPoolRegion = props.UserPoolArn.split(":")[3];
-  const cognitoClient = new CognitoIdentityServiceProvider({
+  const cognitoClient = new CognitoIdentityProvider({
     region: userPoolRegion,
   });
 
@@ -60,7 +63,7 @@ async function updateUserPoolClient(
 
   // To be able to set the redirect URL's, we must enable OAuth––required by Cognito
   // Vice versa, when removing redirect URL's, we must disable OAuth if there's no more redirect URL's left
-  let AllowedOAuthFlows: string[];
+  let AllowedOAuthFlows: ("code"|"client_credentials"|"implicit")[];
   let AllowedOAuthFlowsUserPoolClient: boolean;
   let AllowedOAuthScopes: string[];
   if (CallbackURLs.length) {
@@ -81,7 +84,7 @@ async function updateUserPoolClient(
   delete existingFields.LastModifiedDate;
   delete existingFields.ClientSecret;
 
-  const input: CognitoIdentityServiceProvider.Types.UpdateUserPoolClientRequest =
+  const input: UpdateUserPoolClientCommandInput =
     {
       ...existingFields,
       AllowedOAuthFlows,
@@ -93,7 +96,7 @@ async function updateUserPoolClient(
       LogoutURLs,
     };
   console.debug("Updating User Pool Client", JSON.stringify(input, null, 4));
-  await cognitoClient.updateUserPoolClient(input).promise();
+  await cognitoClient.updateUserPoolClient(input);
 }
 
 async function undoPriorUpdate(

--- a/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/user-pool-domain/index.ts
+++ b/usecases/mwaa-public-webserver-custom-domain/src/cfn-custom-resources/user-pool-domain/index.ts
@@ -14,7 +14,7 @@ import {
   CloudFormationCustomResourceDeleteEvent,
   CloudFormationCustomResourceUpdateEvent,
 } from "aws-lambda";
-import CognitoIdentityServiceProvider from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { CognitoIdentityProvider } from "@aws-sdk/client-cognito-identity-provider";
 import { sendCfnResponse, Status } from "./cfn-response";
 
 async function ensureCognitoUserPoolDomain(
@@ -27,12 +27,11 @@ async function ensureCognitoUserPoolDomain(
   }
   const newUserPoolId = newUserPoolArn.split("/")[1];
   const newUserPoolRegion = newUserPoolArn.split(":")[3];
-  const cognitoClient = new CognitoIdentityServiceProvider({
+  const cognitoClient = new CognitoIdentityProvider({
     region: newUserPoolRegion,
   });
   const { UserPool } = await cognitoClient
-    .describeUserPool({ UserPoolId: newUserPoolId })
-    .promise();
+    .describeUserPool({ UserPoolId: newUserPoolId });
   if (!UserPool) {
     throw new Error(`User Pool ${newUserPoolArn} does not exist`);
   }

--- a/usecases/mwaa-public-webserver-custom-domain/template.yaml
+++ b/usecases/mwaa-public-webserver-custom-domain/template.yaml
@@ -234,7 +234,7 @@ Globals:
       - ApplyPermissionsBoundary
       - Ref: PermissionsBoundaryPolicyArn
       - Ref: AWS::NoValue
-    Runtime: nodejs14.x
+    Runtime: nodejs18.x
 Resources:
   CheckAuthHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We faced the following error because nodejs14 is no longer supported.
So, I'd like to upgrade nodejs to 18 and aws-sdk to v3.
```
Resource handler returned message: "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions.
```
FYI: To migrate aws-sdk from v2 to v3, I basically used aws-sdk-js-codemod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
