### PR TITLE
Stop Start Usecase - Granting iam:PassRole to be able to recreate MWAA 

### DIFF
--- a/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
+++ b/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
@@ -194,6 +194,13 @@ export class MwaaResumingStack extends MwaaPauseResumeBaseStack {
         resources: ['*'],
       })
     );
+    newEnvironmentFunc.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['iam:PassRole'],
+        resources: ['*'],
+      })
+    );
 
     return newEnvironmentFunc;
   }


### PR DESCRIPTION
*Description of changes:*

The resume/start portion of the Stop Start MWAA usecase is breaking lately. Looks like the 'iam:PassRole' permission is now required to create a new MWAA environment using the AWS SDK. This PR adds the permission to the Lambda function that makes the `mwaa:CreateEnvironment` SDK call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
