### PR TITLE
fix: variable port is not used in mwaa import dag for version 2.5.1

### DIFF
--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.5.1/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.5.1/mwaa_import_data.py
@@ -171,7 +171,7 @@ def importConnection(**context):
                 if(len(row[7]) > 0):
                     port = int(row[7])
                 rows.append(Connection(row[0], row[1],row[2], row[3],row[4],
-                             row[5],row[6], row[7],row[8]))
+                             row[5],row[6], port,row[8]))
 
         if len(rows) > 0:
             session.add_all(rows)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
FIX variable port is not used in mwaa import dag for version 2.5.1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
