### PR TITLE
feat: add mwaa export and import dags for version 2.9.2

### DIFF
--- a/usecases/start-stop-mwaa-environment/README.md
+++ b/usecases/start-stop-mwaa-environment/README.md
@@ -11,6 +11,7 @@
 ![2.6.3](https://img.shields.io/badge/mwaa-v2.6.3-green)
 ![2.7.2](https://img.shields.io/badge/mwaa-v2.7.2-green)
 ![2.8.1](https://img.shields.io/badge/mwaa-v2.8.1-green)
+![2.9.2](https://img.shields.io/badge/mwaa-v2.9.2-green)
 
 <!-- TOC ignore:true -->
 # Contents
@@ -186,7 +187,7 @@ The stack parameters are externalized as environment variables. Here are the par
 | `CDK_DEFAULT_REGION`            | None                                                           | `us-east-1`                                                                  | Your AWS region where MWAA is deployed.                                                                                                                                                  |
 | `MWAA_MAIN_STACK_NAME`          | None                                                           | `mwaa-pause-resume-dev`, `mwaa-pause-resume-stage`, `mwaa-pause-resume-prod` | The name of the top-level stack. If you need to pause and resume multiple MWAA environments, then you can redeploy this project with different stack names to manage those environments. |
 | `MWAA_ENV_NAME`                 | None                                                           | `my-mwaa-env`                                                                | Name of the deployed MWAA environment -- [Check AWS Console](https://console.aws.amazon.com/mwaa/home#environments).                                                                     |
-| `MWAA_ENV_VERSION`              | None                                                           | `2.8.1`, `2.7.2`, `2.6.3`, `2.5.1`, `2.4.3`, `2.2.2`, `2.0.2`  | Version of the deployed MWAA environment -- [Check AWS Console](https://console.aws.amazon.com/mwaa/home#environments).                                                                  |
+| `MWAA_ENV_VERSION`              | None                                                           | `2.9.2`, `2.8.1`, `2.7.2`, `2.6.3`, `2.5.1`, `2.4.3`, `2.2.2`, `2.0.2`  | Version of the deployed MWAA environment -- [Check AWS Console](https://console.aws.amazon.com/mwaa/home#environments).                                                                  |
 | `MWAA_SOURCE_BUCKET_NAME`       | None                                                           | `my-mwaa-env-bucket`                                                         | Name of the S3 bucket for the environment that hosts DAGs. Check the environment details page on [AWS Console](https://console.aws.amazon.com/mwaa/home#environments).                   |
 | `MWAA_EXECUTION_ROLE_ARN`       | None                                                           | `arn:aws:iam:...`                                                            | ARN of the execution role for your MWAA environment. Check the environment details page on [AWS Console](https://console.aws.amazon.com/mwaa/home#environments).                         |
 | `MWAA_UPDATE_EXECUTION_ROLE`    | None                                                           | `yes` or `no`                                                                | Flag to denote whether to update the existing MWAA execution role with new policies for allowing task token return calls to the pause and resume StepFunctions                           |

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_export_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_export_data.py
@@ -1,0 +1,310 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from airflow import DAG, settings
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dummy import DummyOperator
+from airflow.utils.dates import days_ago
+from airflow.models import DAG
+from airflow.models import Variable, Connection
+from airflow.hooks.S3_hook import S3Hook
+from sqlalchemy import text
+import csv
+from io import StringIO
+import boto3
+import json
+
+
+"""
+The module iterates through the list of sql statement and table, reads data and stores in S3 as csv file.
+Before it exports the data, it copies all the active dags and pause the execution of all other DAG.
+"""
+# S3 prefix where the exported file are
+S3_KEY = 'data/'
+
+dag_id = 'mwaa_export_data'
+
+STATE_SUCCESS = 'success'
+STATE_RUNNING = 'running'
+
+# Avoids to export 'mwaa_export_data' dag as 'running' state because it behaves just like "catchup=True" and runs some duplicate tasks
+DAG_RUN_SELECT = f"select dag_id, clear_number, execution_date, state, run_id, external_trigger, \
+'\\x' || encode(conf,'hex') as conf, end_date, start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, \
+updated_at from dag_run where dag_id <> '{dag_id}' or state <> '{STATE_RUNNING}' \
+UNION \
+select dag_id, clear_number, execution_date, '{STATE_SUCCESS}' as state, run_id, external_trigger, \
+'\\x' || encode(conf,'hex') as conf, '{days_ago(0)}'::timestamp as end_date, start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, \
+updated_at from dag_run where dag_id = '{dag_id}' and state = '{STATE_RUNNING}' "
+
+TASK_INSTANCE_SELECT = "select task_id, dag_id, run_id, custom_operator_name, start_date, end_date, duration, state, task_display_name, \
+try_number, hostname, unixname, job_id, pool, queue, priority_weight, \
+operator, queued_dttm, rendered_map_index, pid, max_tries, '\\x' || encode(executor_config,'hex') as executor_config ,\
+pool_slots, queued_by_job_id, external_executor_id, trigger_id ,\
+trigger_timeout, next_method, next_kwargs, map_index, updated_at from task_instance \
+where state NOT IN ('running','restarting','queued','scheduled', 'up_for_retry','up_for_reschedule')"
+
+LOG_SELECT = "select dttm, dag_id, task_id, event, execution_date, owner, owner_display_name, run_id, extra from log"
+
+TASK_FAIL_SELECT = "select task_id, dag_id, run_id, map_index, start_date, end_date, duration from task_fail"
+
+JOB_SELECT = "select dag_id,  state, job_type , start_date, \
+end_date, latest_heartbeat, executor_class, hostname, unixname from job"
+
+POOL_SLOTS = "select pool, slots, description, include_deferred from slot_pool where pool != 'default_pool'"
+DATASET = "select uri, extra, created_at, updated_at from dataset"
+DATASET_QUEUE = "select dataset_id, target_dag_id,  created_at  from dataset_dag_run_queue"
+DATASET_EVENT = "select dataset_id, extra, source_task_id, source_dag_id, source_run_id,source_map_index,timestamp from dataset_event"
+DATASET_SCHEDULE = "select dataset_id, dag_id, created_at, updated_at  from dag_schedule_dataset_reference"
+TRIGGER = "select classpath, kwargs, created_date, triggerer_id from trigger"
+DAGRUN_DATASET_EVENT = "select dag_run_id, event_id from dagrun_dataset_event"
+
+
+##################
+# Add more tables If you need
+##################
+
+
+# This object contains the statement to select and the table name
+# The data is exported to the S3 Bucket defined at the top.
+
+##################
+# If you add newer tables, They need an entry here as well
+##################
+
+OBJECTS_TO_EXPORT = [
+    [DAG_RUN_SELECT, "dag_run"],
+    [TASK_INSTANCE_SELECT, "task_instance"],
+    [LOG_SELECT, "log"],
+    [TASK_FAIL_SELECT, "task_fail"],
+    [JOB_SELECT, "job"],
+    [DATASET, "dataset"],
+    [DATASET_SCHEDULE, "dag_schedule_dataset_reference"],
+    [DATASET_EVENT, "dataset_event"],
+    [DATASET_QUEUE, "dataset_dag_run_queue"],
+    [DAGRUN_DATASET_EVENT, "dagrun_dataset_event"],
+    [TRIGGER, "trigger"],
+    [POOL_SLOTS, "slot_pool"]
+]
+
+
+def stream_to_S3_fn(context, result, filename):
+    from smart_open import open
+
+    s3_file = f"s3://{get_s3_bucket(context)}/{S3_KEY}{filename}.csv"
+    # only get 10K rows at a time
+    REC_COUNT = 5000
+    outfileStr = ""
+    with open(s3_file, 'wb') as write_io:
+        while True:
+            chunk = result.fetchmany(REC_COUNT)
+            if not chunk:
+                break
+            f = StringIO(outfileStr)
+            w = csv.writer(f)
+            w.writerows(chunk)
+            write_io.write(f.getvalue().encode("utf8"))
+        write_io.close()
+
+# pause all active dags to have consistent and reliable copy of dag history exports
+def pause_dags():
+    session = settings.Session()
+    session.execute(
+        text(f"update dag set is_paused = true where dag_id != '{dag_id}';"))
+    session.commit()
+    session.close()
+
+
+# Exports all active dags to S3; This data is used to unpause the dag in the new environment
+def export_active_dags(**context):
+    session = settings.Session()
+    result = session.execute("select * from active_dags")
+    stream_to_S3_fn(context, result, 'active_dags')
+    session.close()
+
+
+# exports variable. Variable value is encrypted;
+# So, the method uses the Variable class to decrypt the value and exports the data
+def export_variable(**context):
+    session = settings.Session()
+    s3_hook = S3Hook()
+    s3_client = s3_hook.get_conn()
+    query = session.query(Variable)
+    allrows = query.all()
+    k = ["key", "val", "is_encrypted", "description"]
+    if len(allrows) > 0:
+        outfileStr = ""
+        f = StringIO(outfileStr)
+        w = csv.DictWriter(f,  k)
+        for y in allrows:
+            w.writerow({k[0]: y.key, k[1]: y.get_val(),
+                       k[2]: y.is_encrypted, k[3]: None})
+        outkey = S3_KEY + 'variable.csv'
+        s3_client.put_object(Bucket=get_s3_bucket(context), Key=outkey, Body=f.getvalue())
+    session.close()
+
+    return "OK"
+
+def export_connection(**context):
+    session = settings.Session()
+    s3_hook = S3Hook()
+    s3_client = s3_hook.get_conn()
+    query = session.query(Connection)
+    allrows = query.all()
+    k = ["conn_id", "conn_type", "host", "schema","login","password","port","extra","is_encrypted","is_extra_encrypted","description"]
+    if len(allrows) > 0:
+        outfileStr = ""
+        f = StringIO(outfileStr)
+        w = csv.DictWriter(f,  k)
+        for y in allrows:
+
+
+            w.writerow({k[0]: y.conn_id, k[1]: y.conn_type, k[2]: y.description, k[3]: y.host,
+                        k[4]: y.login, k[5]: y.get_password(),k[6]: y.schema, k[7]: y.port,
+                        k[8]: y.get_extra()})
+
+        outkey = S3_KEY + 'connection.csv'
+        s3_client.put_object(Bucket=get_s3_bucket(context), Key=outkey, Body=f.getvalue())
+    session.close()
+
+    return "OK"
+
+
+# backsup the active dags before pausing them
+def back_up_activedags():
+    session = settings.Session()
+    session.execute(text(f"drop table if exists active_dags;"))
+    session.execute(text(
+        f"create table active_dags as select dag_id from dag where not is_paused and is_active;"))
+    session.commit()
+    session.close()
+
+# Activate dags
+def activate_dags():
+    session = settings.Session()
+    conn = settings.engine.raw_connection()
+    try:
+        session.execute(text(f"UPDATE dag d SET is_paused=false FROM active_dags ed WHERE d.dag_id = ed.dag_id;"))
+        session.execute(text(f"drop table active_dags;"))
+        session.commit()
+    finally:
+        conn.close()
+
+
+# iterate OBJECTS_TO_EXPORT and call export
+def export_data(**context):
+    session = settings.Session()
+
+    for x in OBJECTS_TO_EXPORT:
+        result = session.execute(text(x[0]))
+        stream_to_S3_fn(context, result, x[1])
+
+    session.close()
+    return "OK"
+
+
+# Export Failure/Success notification
+def get_s3_bucket(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['bucket']
+
+
+def get_task_token(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['taskToken']
+
+
+def get_dag_run_result(context):
+    dag_run = context.get('dag_run')
+    task_instances = dag_run.get_task_instances()
+    task_states = []
+    for task in task_instances:
+        task_states.append(f'{task.task_id} => {task.state}')
+    return {'dag': dag_run.dag_id, 'dag_run': dag_run.run_id, 'tasks': task_states}
+
+
+def notify_success(**context):
+    result = get_dag_run_result(context)
+    result['location'] = f's3://{get_s3_bucket(context)}/{S3_KEY}'
+    result['status'] = 'Success'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_success(taskToken=token, output=json.dumps(result))
+
+
+def notify_failure(context):
+    result = get_dag_run_result(context)
+    result['status'] = 'Fail'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_failure(taskToken=token, error='Export Error', cause=json.dumps(result))
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'on_failure_callback': notify_failure
+}
+with DAG(dag_id=dag_id, schedule_interval=None, catchup=False, default_args=default_args) as dag:
+
+    back_up_activedags_t = PythonOperator(
+        task_id="back_up_activedags",
+        python_callable=back_up_activedags
+    )
+    pause_dags_t = PythonOperator(
+        task_id="pause_dags",
+        python_callable=pause_dags
+    )
+    export_active_dags_t = PythonOperator(
+        task_id="export_active_dags",
+        python_callable=export_active_dags,
+        provide_context=True
+    )
+    export_variable_t = PythonOperator(
+        task_id="export_variable",
+        python_callable=export_variable,
+        provide_context=True
+    )
+
+    export_data_t = PythonOperator(
+        task_id="export_data",
+        python_callable=export_data,
+        provide_context=True
+    )
+    export_connection_t = PythonOperator(
+        task_id="export_connection",
+        python_callable=export_connection,
+        provide_context=True
+    )
+
+    clean_up_t = DummyOperator(task_id='clean_up')
+
+    notify_success_t = PythonOperator(
+        task_id='notify_success',
+        python_callable=notify_success,
+        provide_context=True
+    )
+
+    activate_dags_on_failure_t = PythonOperator(
+        task_id="activate_dags_on_failure",
+        python_callable=activate_dags,
+        trigger_rule="one_failed"
+    )
+
+    back_up_activedags_t >> pause_dags_t >> [export_data_t, export_active_dags_t, export_variable_t, export_connection_t] >> clean_up_t >> [activate_dags_on_failure_t, notify_success_t]

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_import_data.py
@@ -1,0 +1,324 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from airflow import DAG, settings
+
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+from sqlalchemy import text
+import boto3
+import botocore
+from airflow.utils.task_group import TaskGroup
+import os
+import csv
+from airflow.models import Variable,Connection
+import json
+
+"""
+This module imports data in to the table from the data exported by the export script
+This iterate through OBJECTS_TO_IMPORT which contains COPY statement and the csv file with data.
+This module also copies a configurabled days of task instance log from Cloud Watch
+
+"""
+# S3 prefix to look for exported data
+S3_KEY = 'data/'
+
+dag_id = 'mwaa_import_data'
+
+DAG_RUN_IMPORT = "COPY \
+dag_run(dag_id, clear_number, execution_date, state, run_id, external_trigger, \
+conf, end_date,start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, updated_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+TASK_INSTANCE_IMPORT = "COPY task_instance(task_id, dag_id, run_id, custom_operator_name, start_date, end_date, \
+duration, state, task_display_name, try_number, hostname, unixname, job_id, pool, \
+queue, priority_weight, operator, queued_dttm, rendered_map_index, pid, max_tries, executor_config,\
+pool_slots, queued_by_job_id, external_executor_id, trigger_id , \
+trigger_timeout, next_method, next_kwargs, map_index, updated_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+TASK_FAIL_IMPORT = "COPY task_fail(task_id, dag_id, run_id, map_index, \
+ start_date, end_date, duration) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+
+JOB_IMPORT = "COPY JOB(dag_id,  state, job_type , start_date, \
+                end_date, latest_heartbeat, executor_class, hostname, unixname) \
+                FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+
+LOG_IMPORT = "COPY log(dttm, dag_id, task_id, event, execution_date, owner, owner_display_name, run_id, extra) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+POOL_SLOTS = "COPY slot_pool(pool, slots, description, include_deferred) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+DATASET = "COPY dataset(uri, extra, created_at, updated_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+DATASET_QUEUE = "COPY dataset_dag_run_queue(dataset_id, target_dag_id,  created_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+DATASET_EVENT = "COPY dataset_event(dataset_id, extra, source_task_id, source_dag_id, \
+                    source_run_id,source_map_index,timestamp) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+DATASET_SCHEDULE = "COPY dag_schedule_dataset_reference(dataset_id, dag_id, created_at, updated_at) \
+                        FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+TRIGGER = "COPY trigger(classpath, kwargs, created_date, triggerer_id)\
+             FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+DAGRUN_DATASET_EVENT = "COPY dagrun_dataset_event(dag_run_id, event_id)\
+             FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+
+OBJECTS_TO_IMPORT = [
+    [DAG_RUN_IMPORT, "dag_run.csv"],
+    [LOG_IMPORT, "log.csv"],
+    [JOB_IMPORT, "job.csv"],
+    [POOL_SLOTS, "slot_pool.csv"],
+    [DATASET, "dataset.csv"],
+
+]
+
+DS_IMPORT = [
+    [DATASET_SCHEDULE, "dag_schedule_dataset_reference.csv"],
+    [DATASET_EVENT, "dataset_event.csv"],
+    [DATASET_QUEUE, "dataset_dag_run_queue.csv"],
+
+]
+
+# pause all dags before starting export
+def pause_dags():
+    session = settings.Session()
+    session.execute(text(f"update dag set is_paused = true where dag_id != '{dag_id}';"))
+    session.commit()
+    session.close()
+
+def read_s3(context, filename):
+    resource = boto3.resource('s3')
+    bucket = resource.Bucket(get_s3_bucket(context))
+    tempfile = f"/tmp/{filename}"
+    try:
+        bucket.download_file(S3_KEY + filename, tempfile)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "404":
+            return None
+        else:
+            raise
+    else:
+        return tempfile
+
+
+def activate_dags(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, "active_dags.csv")
+    if (not tempfile):
+        return
+
+    conn = settings.engine.raw_connection()
+    try:
+        session.execute(
+            text(f"create table if not exists active_dags(dag_id varchar(250))"))
+        session.commit()
+        with open(tempfile, 'r') as f:
+            cursor = conn.cursor()
+            cursor.copy_expert(
+                "COPY active_dags FROM STDIN WITH (FORMAT CSV, HEADER TRUE)", f)
+            conn.commit()
+        session.execute(text(
+            f"UPDATE dag d SET is_paused=false FROM active_dags ed WHERE d.dag_id = ed.dag_id;"))
+        session.commit()
+    finally:
+        conn.close()
+
+# Variables are imported separately as they are encyrpted
+def importVariable(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, 'variable.csv')
+    if (not tempfile):
+        return
+
+    with open(tempfile, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        rows = []
+        for row in reader:
+            rowexist = session.query(Variable).filter(Variable.key==row[0]).all()
+            if (len(rowexist)==0):
+                rows.append(Variable(row[0], row[1]))
+            else:
+                print(f"Already Exists Varible {list(rowexist)}")
+        if len(rows) > 0:
+            session.add_all(rows)
+    session.commit()
+    session.close()
+
+
+def importConnection(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, 'connection.csv')
+    if (not tempfile):
+        return
+
+    with open(tempfile, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        rows = []
+        for row in reader:
+            rowexist = session.query(Connection).filter(Connection.conn_id==row[0]).all()
+            if(len(rowexist) == 0):
+                port = 0
+                if(len(row[7]) > 0):
+                    port = int(row[7])
+                rows.append(Connection(row[0], row[1],row[2], row[3],row[4],
+                             row[5],row[6], port,row[8]))
+
+        if len(rows) > 0:
+            session.add_all(rows)
+    session.commit()
+    session.close()
+
+
+def load_data(**context):
+    query = context['query']
+    tempfile = read_s3(context, context['file'])
+    if (not tempfile):
+        return
+
+    conn = settings.engine.raw_connection()
+    try:
+        with open(tempfile, 'r') as f:
+            cursor = conn.cursor()
+            cursor.copy_expert(query, f)
+            conn.commit()
+    finally:
+        conn.close()
+        os.remove(tempfile)
+
+
+# Export Failure/Success notification functions
+def get_s3_bucket(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['bucket']
+
+
+def get_task_token(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['taskToken']
+
+
+def get_dag_run_result(context):
+    dag_run = context.get('dag_run')
+    task_instances = dag_run.get_task_instances()
+    task_states = []
+    for task in task_instances:
+        task_states.append(f'{task.task_id} => {task.state}')
+    return {'dag': dag_run.dag_id, 'dag_run': dag_run.run_id, 'tasks': task_states}
+
+
+def notify_success(**context):
+    result = get_dag_run_result(context)
+    result['location'] = f's3://{get_s3_bucket(context)}/{S3_KEY}'
+    result['status'] = 'Success'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_success(taskToken=token, output=json.dumps(result))
+
+
+def notify_failure(context):
+    result = get_dag_run_result(context)
+    result['status'] = 'Fail'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_failure(
+        taskToken=token, error='Import Error', cause=json.dumps(result))
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'on_failure_callback': notify_failure
+}
+with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=default_args) as dag:
+
+    pause_dags_t = PythonOperator(
+        task_id="pause_dags",
+        python_callable=pause_dags
+    )
+    with TaskGroup(group_id='toplevel_tables') as import_t:
+        for x in OBJECTS_TO_IMPORT:
+            load_task = PythonOperator(
+                task_id=x[1],
+                python_callable=load_data,
+                op_kwargs={'query': x[0], 'file': x[1]},
+                provide_context=True
+            )
+        load_variable_t = PythonOperator(
+            task_id="variable",
+            python_callable=importVariable,
+            provide_context=True
+        )
+        load_connection_t = PythonOperator(
+            task_id="connection",
+            python_callable=importConnection,
+            provide_context=True
+        )
+
+    pause_dags_t >> import_t
+    load_task_instance = PythonOperator(
+        task_id="load_ti",
+        op_kwargs={'query': TASK_INSTANCE_IMPORT, 'file': 'task_instance.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    load_triggers = PythonOperator(
+        task_id="load_trg",
+        op_kwargs={'query': TRIGGER, 'file': 'trigger.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    import_t >> load_triggers >> load_task_instance
+
+    with TaskGroup(group_id='import_ds_tables') as load_ds_sets:
+       for x in DS_IMPORT:
+            load_task = PythonOperator(
+                task_id=x[1],
+                python_callable=load_data,
+                op_kwargs={'query': x[0], 'file': x[1]},
+                provide_context=True
+            )
+    load_task_instance >> load_ds_sets
+
+    taskfail_dagrun = PythonOperator(
+        task_id="task_fail_run",
+        op_kwargs={'query': TASK_FAIL_IMPORT, 'file': 'task_fail.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    load_task_instance >> taskfail_dagrun
+
+    load_ds_dagrun = PythonOperator(
+        task_id="load_ds_run",
+        op_kwargs={'query': DAGRUN_DATASET_EVENT, 'file': 'dataset_dag_run_event.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    load_ds_sets >> load_ds_dagrun
+
+    activate_dags_t = PythonOperator(
+        task_id="activate_dags",
+        python_callable=activate_dags,
+        provide_context=True
+    )
+    load_task_instance >> activate_dags_t
+
+    notify_success_t = PythonOperator(
+        task_id='notify_success',
+        python_callable=notify_success,
+        provide_context=True
+    )
+    activate_dags_t >> notify_success_t
+    taskfail_dagrun >> notify_success_t
+    load_ds_dagrun >> notify_success_t


### PR DESCRIPTION
The main db schema difference between 2.8.1 and 2.9.2 are in tables task_instance and log. Table task_instance has new columns task_display_name and rendered_map_index. Table log has new column run_id.

*Issue #, if available:*

*Description of changes:*
Since AWS MWAA has released version 2.9.2, I added again export and import DAGs for it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
