### PR TITLE
fix: give permissions to MWAA start stop to re-add tags to environment on resume

### DIFF
--- a/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
+++ b/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
@@ -247,7 +247,7 @@ export class MwaaResumingStack extends MwaaPauseResumeBaseStack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         resources: [`arn:aws:airflow:${props.region}:${props.account}:environment/${props.environmentName}`],
-        actions: ['airflow:UpdateEnvironment'],
+        actions: ['airflow:UpdateEnvironment', 'airflow:TagResource'],
       })
     );
     updateEnvironmentFunc.addToRolePolicy(

--- a/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
+++ b/usecases/start-stop-mwaa-environment/lib/infrastructure/mwaa-resuming-stack.ts
@@ -142,7 +142,7 @@ export class MwaaResumingStack extends MwaaPauseResumeBaseStack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         resources: [`arn:aws:airflow:${props.region}:${props.account}:environment/${props.environmentName}`],
-        actions: ['airflow:CreateEnvironment'],
+        actions: ['airflow:CreateEnvironment', 'airflow:TagResource'],
       })
     );
     newEnvironmentFunc.addToRolePolicy(


### PR DESCRIPTION
*Issue #84*

*Description of changes:*

Added `airflow:TagResource` to create and update environment role permissions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
