### PR TITLE
Fixing duplicated resource in CloudFormation template. Updating RDS instance

### DIFF
--- a/usecases/mwaa-glue-athena/RDSMWAA.yaml
+++ b/usecases/mwaa-glue-athena/RDSMWAA.yaml
@@ -234,20 +234,6 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable2
       SubnetId: !Ref PrivateSubnet2
 
-  SecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: "mwaa-security-group"
-      GroupDescription: "Security group with a self-referencing inbound rule."
-      VpcId: !Ref VPC
-
-  SecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !Ref SecurityGroup
-      IpProtocol: "-1"
-      SourceSecurityGroupId: !Ref SecurityGroup
-
   MWAAEnvironmentBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -308,11 +294,11 @@ Resources:
       AllocatedStorage: '500'
       AllowMajorVersionUpgrade: false
       AutoMinorVersionUpgrade: true
-      DBInstanceClass: db.t2.2xlarge
+      DBInstanceClass: db.m5d.2xlarge
       DBInstanceIdentifier: postgreinstance
       Port: '5432'
       PubliclyAccessible: true
-      StorageType: gp2
+      StorageType: gp3
       BackupRetentionPeriod: 7
       MasterUsername: adminuser
       MasterUserPassword: admin123
@@ -320,7 +306,7 @@ Resources:
       PreferredMaintenanceWindow: sun:05:20-sun:05:50
       DBName: sportstickets
       Engine: postgres
-      EngineVersion: '11.20'
+      EngineVersion: '16.4'
       LicenseModel: postgresql-license
       DBSubnetGroupName: !Ref RDSDefaultDBSubnet
       VPCSecurityGroups:


### PR DESCRIPTION
…nstance class, Engine and Storage Type due to deprecation of old ones

*Issue #, if available:*

*Description of changes:*
The CFN template didn't work because: 1/ there was a duplicated resource name. 2/The RDS instance used is no longer supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
