### PR TITLE
Add AI Loan Approval Agent use case for MWAA Serverless

### DIFF
--- a/serverless/usecases/loan-approval-agent/README.md
+++ b/serverless/usecases/loan-approval-agent/README.md
@@ -1,0 +1,198 @@
+# AI Loan Approval Agent — MWAA Serverless
+
+An agentic AI workflow that processes loan applications using parallel AI agents for due diligence and income verification, then makes an automated approval decision.
+
+Built entirely with [Amazon MWAA Serverless](https://docs.aws.amazon.com/mwaa/latest/mwaa-serverless-userguide/what-is-mwaa-serverless.html) — no custom code, no infrastructure to manage.
+
+## Architecture
+
+```
+                    ┌─────────────────────────────┐
+                    │     Loan Application         │
+                    │  (name, income, occupation,  │
+                    │       loan amount)           │
+                    └──────────┬──────────────────┘
+                               │
+                 ┌─────────────┴─────────────┐
+                 │                           │
+                 ▼                           ▼
+    ┌────────────────────┐     ┌────────────────────────┐
+    │  Agent 1:          │     │  Agent 2:              │
+    │  Due Diligence     │     │  Income Verification   │
+    │  (BedrockInvoke)   │     │  (BedrockRaG)          │
+    │                    │     │                        │
+    │  • Risk scoring    │     │  • Salary benchmarks   │
+    │  • Debt-to-income  │     │  • Industry ranges     │
+    │  • Red flags       │     │  • Plausibility check  │
+    └────────┬───────────┘     └───────────┬────────────┘
+             │                             │
+             └──────────┬──────────────────┘
+                        ▼
+           ┌────────────────────────┐
+           │  Agent 3:              │
+           │  Loan Decision         │
+           │  (BedrockInvoke)       │
+           │                        │
+           │  APPROVED / DENIED /   │
+           │  MANUAL_REVIEW         │
+           └────────────┬───────────┘
+                        │
+              ┌─────────┴─────────┐
+              ▼                   ▼
+    ┌──────────────┐    ┌──────────────┐
+    │ SNS Notify   │    │ S3 Audit Log │
+    └──────────────┘    └──────────────┘
+```
+
+## What Makes It Agentic
+
+| Capability | How It Works |
+|---|---|
+| **Perception** | Receives structured application data as workflow params |
+| **Parallel Reasoning** | Two AI agents independently assess risk and verify income |
+| **Decision Making** | A third agent synthesizes both reports into a final decision |
+| **Action** | Notifies the applicant and logs the decision for audit |
+
+## Operators Used
+
+All from the [Amazon Provider Package](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/index.html) (MWAA Serverless compatible):
+
+- `BedrockInvokeModelOperator` — Due diligence risk assessment + final decision
+- `BedrockRaGOperator` — Income verification against salary benchmark knowledge base
+- `SnsPublishOperator` — Applicant notification
+- `S3CreateObjectOperator` — Audit trail
+
+## Prerequisites
+
+- [AWS CLI](https://aws.amazon.com/cli/) v2.31.38+
+- An AWS account with [Amazon Bedrock](https://aws.amazon.com/bedrock/) model access enabled for:
+  - `anthropic.claude-sonnet-4-20250514-v1:0` (inference via `us.anthropic.claude-sonnet-4-20250514-v1:0` inference profile)
+  - `amazon.titan-embed-text-v2:0` (embeddings for Knowledge Base)
+- Sufficient IAM permissions to create S3 buckets, IAM roles, SNS topics, Bedrock Knowledge Bases, S3 Vector buckets, and MWAA Serverless workflows
+
+## Quick Start
+
+### 1. Deploy everything
+
+```bash
+chmod +x setup/deploy.sh
+./setup/deploy.sh
+```
+
+This single script creates:
+- S3 bucket with salary benchmark data
+- S3 Vector bucket and index for embeddings
+- Bedrock Knowledge Base with S3 Vectors storage
+- SNS topic for notifications
+- IAM roles for MWAA Serverless and Bedrock
+- The MWAA Serverless workflow
+
+The deploy script is idempotent — safe to re-run if interrupted.
+
+### 2. Run a loan application
+
+```bash
+aws mwaa-serverless start-workflow-run \
+  --workflow-arn <WORKFLOW_ARN from deploy output> \
+  --override-parameters '{"applicant_name":"Jane Doe","occupation":"software_engineer","yearly_income":95000,"loan_amount":350000}' \
+  --region us-east-1
+```
+
+### 3. Check the result
+
+```bash
+aws mwaa-serverless get-workflow-run \
+  --workflow-arn <WORKFLOW_ARN> \
+  --run-id <RUN_ID from step 2> \
+  --region us-east-1
+```
+
+### 4. Try different scenarios
+
+```bash
+# High-risk: teacher requesting large loan
+aws mwaa-serverless start-workflow-run \
+  --workflow-arn <WORKFLOW_ARN> \
+  --override-parameters '{"applicant_name":"Bob Smith","occupation":"teacher","yearly_income":52000,"loan_amount":500000}' \
+  --region us-east-1
+
+# Low-risk: senior engineer, modest loan
+aws mwaa-serverless start-workflow-run \
+  --workflow-arn <WORKFLOW_ARN> \
+  --override-parameters '{"applicant_name":"Alice Chen","occupation":"software_engineer","yearly_income":180000,"loan_amount":200000}' \
+  --region us-east-1
+
+# Suspicious: nurse with inflated income
+aws mwaa-serverless start-workflow-run \
+  --workflow-arn <WORKFLOW_ARN> \
+  --override-parameters '{"applicant_name":"Tom Wilson","occupation":"nurse","yearly_income":250000,"loan_amount":400000}' \
+  --region us-east-1
+```
+
+## Clean Up
+
+```bash
+chmod +x setup/teardown.sh
+./setup/teardown.sh
+```
+
+## Project Structure
+
+```
+loan-approval-agent/
+├── README.md                  # This file
+├── loan_approval_agent.yaml              # MWAA Serverless workflow definition
+├── provisioned/
+│   └── loan_approval_agent_dag.py  # Python DAG for MWAA Provisioned
+└── setup/
+    ├── deploy.sh              # One-command setup
+    ├── teardown.sh            # One-command cleanup
+    ├── trust-policy.json      # IAM trust policy
+    └── salary-data/           # Synthetic data for Knowledge Base
+        ├── accountant.txt
+        ├── nurse.txt
+        ├── sales_manager.txt
+        ├── software_engineer.txt
+        └── teacher.txt
+```
+
+## MWAA Serverless vs. Provisioned
+
+This example includes two versions of the same workflow:
+
+| | Serverless (`loan_approval_agent.yaml`) | Provisioned (`provisioned/loan_approval_agent_dag.py`) |
+|---|---|---|
+| **Format** | YAML (DAG Factory) | Python |
+| **Deployment** | `deploy.sh` creates the workflow | Copy DAG to your MWAA environment's S3 DAGs folder |
+| **Configuration** | Placeholders rendered by `deploy.sh` | Airflow Variables (`Admin > Variables`) |
+| **Infrastructure** | Fully managed, no environment needed | Requires an existing MWAA environment |
+| **Cost model** | Pay per task execution | Hourly rate for always-on environment |
+| **Custom code** | Not supported | Full Python flexibility |
+
+### Using the Provisioned DAG
+
+1. Run `setup/deploy.sh` to create the Knowledge Base, S3 bucket, and SNS topic (or create them manually).
+2. Set the following [Airflow Variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html) in your MWAA environment:
+   - `loan_approval_knowledge_base_id` — Your Bedrock Knowledge Base ID
+   - `loan_approval_sns_topic_arn` — Your SNS topic ARN
+   - `loan_approval_s3_bucket` — Your S3 bucket name
+3. Copy `provisioned/loan_approval_agent_dag.py` to your MWAA environment's DAGs S3 folder.
+4. Trigger the DAG from the Airflow UI with custom parameters.
+
+## Cost
+
+This demo uses pay-per-use services only:
+- **MWAA Serverless**: Charged per task execution time
+- **Bedrock**: Charged per input/output token
+- **S3, SNS**: Negligible for demo usage
+- **Bedrock Knowledge Base (S3 Vectors)**: Storage costs only
+
+Run `teardown.sh` when done to avoid ongoing charges.
+
+## Security
+
+See [CONTRIBUTING](../../../CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License. See the [LICENSE](../../../LICENSE) file.

--- a/serverless/usecases/loan-approval-agent/loan_approval_agent.yaml
+++ b/serverless/usecases/loan-approval-agent/loan_approval_agent.yaml
@@ -1,0 +1,112 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+loan_approval_agent:
+  dag_id: loan_approval_agent
+  schedule: None
+  params:
+    applicant_name:
+      type: string
+      default: "Jane Doe"
+    occupation:
+      type: string
+      default: "software_engineer"
+    yearly_income:
+      type: number
+      default: 95000
+    loan_amount:
+      type: number
+      default: 350000
+  tasks:
+
+    # ── Agent 1: Due Diligence (runs in parallel with income_verification) ──
+    due_diligence:
+      operator: airflow.providers.amazon.aws.operators.bedrock.BedrockInvokeModelOperator
+      model_id: "${INFERENCE_PROFILE}"
+      input_data:
+        anthropic_version: "bedrock-2023-05-31"
+        max_tokens: 1024
+        messages:
+          - role: "user"
+            content: >
+              You are a loan underwriting analyst. Assess the risk for this application:
+
+              - Applicant: {{ params.applicant_name }}
+              - Occupation: {{ params.occupation }}
+              - Yearly Income: ${{ params.yearly_income }}
+              - Loan Amount Requested: ${{ params.loan_amount }}
+
+              Evaluate:
+              1. Debt-to-income ratio (assume standard monthly expenses for the occupation)
+              2. Loan-to-income ratio and whether it falls within acceptable limits
+              3. Any red flags based on the occupation and requested amount
+
+              Return a JSON object with keys: risk_score (1-10), risk_factors (array), recommendation (string)
+
+    # ── Agent 2: Income Verification via RAG (runs in parallel with due_diligence) ──
+    income_verification:
+      operator: airflow.providers.amazon.aws.operators.bedrock.BedrockRaGOperator
+      source_type: "KNOWLEDGE_BASE"
+      model_arn: "${INFERENCE_PROFILE}"
+      knowledge_base_id: "${KNOWLEDGE_BASE_ID}"
+      input: >
+        Verify if a yearly income of ${{ params.yearly_income }} is plausible
+        for someone working as a {{ params.occupation }}.
+        Check the salary ranges and flag any concerns.
+        Return a JSON object with keys: verified (boolean), confidence (high/medium/low),
+        expected_range (string), notes (string)
+
+    # ── Agent 3: Final Decision (waits for both agents) ──
+    loan_decision:
+      operator: airflow.providers.amazon.aws.operators.bedrock.BedrockInvokeModelOperator
+      model_id: "${INFERENCE_PROFILE}"
+      input_data:
+        anthropic_version: "bedrock-2023-05-31"
+        max_tokens: 1024
+        messages:
+          - role: "user"
+            content: >
+              You are a senior loan officer making a final decision.
+
+              Application:
+              - Applicant: {{ params.applicant_name }}
+              - Occupation: {{ params.occupation }}
+              - Income: ${{ params.yearly_income }}
+              - Loan Amount: ${{ params.loan_amount }}
+
+              Due Diligence Report:
+              {{ ti.xcom_pull(task_ids="due_diligence") }}
+
+              Income Verification Report:
+              {{ ti.xcom_pull(task_ids="income_verification") }}
+
+              Based on both reports, make a final decision.
+              Return a JSON object with keys:
+              decision (APPROVED/DENIED/MANUAL_REVIEW),
+              reasoning (string), conditions (array of strings, if any)
+      dependencies: [due_diligence, income_verification]
+
+    # ── Notify: Send decision via SNS ──
+    notify_applicant:
+      operator: airflow.providers.amazon.aws.operators.sns.SnsPublishOperator
+      target_arn: "${SNS_TOPIC_ARN}"
+      message: >
+        Loan Application Decision for {{ params.applicant_name }}:
+        {{ ti.xcom_pull(task_ids="loan_decision") }}
+      subject: "Loan Application Decision - {{ params.applicant_name }}"
+      dependencies: [loan_decision]
+
+    # ── Audit: Log decision to S3 ──
+    log_decision:
+      operator: airflow.providers.amazon.aws.operators.s3.S3CreateObjectOperator
+      s3_bucket: "${S3_BUCKET}"
+      s3_key: "audit/{{ ds }}/{{ params.applicant_name }}.json"
+      data: >
+        {
+          "applicant": "{{ params.applicant_name }}",
+          "occupation": "{{ params.occupation }}",
+          "income": {{ params.yearly_income }},
+          "loan_amount": {{ params.loan_amount }},
+          "decision": {{ ti.xcom_pull(task_ids="loan_decision") }}
+        }
+      replace: true
+      dependencies: [loan_decision]

--- a/serverless/usecases/loan-approval-agent/provisioned/loan_approval_agent_dag.py
+++ b/serverless/usecases/loan-approval-agent/provisioned/loan_approval_agent_dag.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# AI Loan Approval Agent — MWAA Provisioned (Python DAG)
+#
+# This DAG implements the same agentic loan approval workflow as the
+# MWAA Serverless YAML version, but as a standard Python DAG for use
+# with provisioned Amazon MWAA environments.
+#
+# Before using this DAG, you must:
+#   1. Run the setup/deploy.sh script to create the Knowledge Base and
+#      supporting resources, OR create them manually.
+#   2. Set the following Airflow Variables (Admin > Variables):
+#      - loan_approval_knowledge_base_id : Your Bedrock Knowledge Base ID
+#      - loan_approval_sns_topic_arn     : Your SNS topic ARN
+#      - loan_approval_s3_bucket         : Your S3 bucket name
+#
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+from airflow.providers.amazon.aws.operators.bedrock import (
+    BedrockInvokeModelOperator,
+    BedrockRaGOperator,
+)
+from airflow.providers.amazon.aws.operators.s3 import S3CreateObjectOperator
+from airflow.providers.amazon.aws.operators.sns import SnsPublishOperator
+
+INFERENCE_PROFILE = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+KNOWLEDGE_BASE_ID = "{{ var.value.loan_approval_knowledge_base_id }}"
+SNS_TOPIC_ARN = "{{ var.value.loan_approval_sns_topic_arn }}"
+S3_BUCKET = "{{ var.value.loan_approval_s3_bucket }}"
+
+with DAG(
+    dag_id="loan_approval_agent",
+    schedule=None,
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    params={
+        "applicant_name": Param("Jane Doe", type="string"),
+        "occupation": Param("software_engineer", type="string"),
+        "yearly_income": Param(95000, type="number"),
+        "loan_amount": Param(350000, type="number"),
+    },
+    tags=["bedrock", "agentic-ai", "loan-approval"],
+) as dag:
+
+    # ── Agent 1: Due Diligence (parallel) ──
+    due_diligence = BedrockInvokeModelOperator(
+        task_id="due_diligence",
+        model_id=INFERENCE_PROFILE,
+        input_data={
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": """You are a loan underwriting analyst. Assess the risk for this application:
+
+- Applicant: {{ params.applicant_name }}
+- Occupation: {{ params.occupation }}
+- Yearly Income: ${{ params.yearly_income }}
+- Loan Amount Requested: ${{ params.loan_amount }}
+
+Evaluate:
+1. Debt-to-income ratio (assume standard monthly expenses for the occupation)
+2. Loan-to-income ratio and whether it falls within acceptable limits
+3. Any red flags based on the occupation and requested amount
+
+Return a JSON object with keys: risk_score (1-10), risk_factors (array), recommendation (string)""",
+                }
+            ],
+        },
+    )
+
+    # ── Agent 2: Income Verification via RAG (parallel) ──
+    income_verification = BedrockRaGOperator(
+        task_id="income_verification",
+        source_type="KNOWLEDGE_BASE",
+        model_arn=INFERENCE_PROFILE,
+        knowledge_base_id=KNOWLEDGE_BASE_ID,
+        input=(
+            "Verify if a yearly income of ${{ params.yearly_income }} is plausible "
+            "for someone working as a {{ params.occupation }}. "
+            "Check the salary ranges and flag any concerns. "
+            "Return a JSON object with keys: verified (boolean), confidence (high/medium/low), "
+            "expected_range (string), notes (string)"
+        ),
+    )
+
+    # ── Agent 3: Final Decision (waits for both) ──
+    loan_decision = BedrockInvokeModelOperator(
+        task_id="loan_decision",
+        model_id=INFERENCE_PROFILE,
+        input_data={
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": """You are a senior loan officer making a final decision.
+
+Application:
+- Applicant: {{ params.applicant_name }}
+- Occupation: {{ params.occupation }}
+- Income: ${{ params.yearly_income }}
+- Loan Amount: ${{ params.loan_amount }}
+
+Due Diligence Report:
+{{ ti.xcom_pull(task_ids="due_diligence") }}
+
+Income Verification Report:
+{{ ti.xcom_pull(task_ids="income_verification") }}
+
+Based on both reports, make a final decision.
+Return a JSON object with keys:
+decision (APPROVED/DENIED/MANUAL_REVIEW),
+reasoning (string), conditions (array of strings, if any)""",
+                }
+            ],
+        },
+    )
+
+    # ── Notify applicant ──
+    notify_applicant = SnsPublishOperator(
+        task_id="notify_applicant",
+        target_arn=SNS_TOPIC_ARN,
+        message=(
+            "Loan Application Decision for {{ params.applicant_name }}: "
+            "{{ ti.xcom_pull(task_ids='loan_decision') }}"
+        ),
+        subject="Loan Application Decision - {{ params.applicant_name }}",
+    )
+
+    # ── Audit log to S3 ──
+    log_decision = S3CreateObjectOperator(
+        task_id="log_decision",
+        s3_bucket=S3_BUCKET,
+        s3_key="audit/{{ ds }}/{{ params.applicant_name }}.json",
+        data=(
+            '{"applicant": "{{ params.applicant_name }}", '
+            '"occupation": "{{ params.occupation }}", '
+            '"income": {{ params.yearly_income }}, '
+            '"loan_amount": {{ params.loan_amount }}, '
+            '"decision": {{ ti.xcom_pull(task_ids="loan_decision") }}}'
+        ),
+        replace=True,
+    )
+
+    # ── Dependencies: fan-out → fan-in ──
+    [due_diligence, income_verification] >> loan_decision >> [notify_applicant, log_decision]

--- a/serverless/usecases/loan-approval-agent/setup/deploy.sh
+++ b/serverless/usecases/loan-approval-agent/setup/deploy.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+
+# ─── Configuration ───────────────────────────────────────────────
+PROJECT="mwaa-loan-approval"
+REGION="${1:-${AWS_REGION:-us-east-1}}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+S3_BUCKET="${PROJECT}-${ACCOUNT_ID}-${REGION}"
+VECTOR_BUCKET_NAME="${PROJECT}-vectors"
+VECTOR_INDEX_NAME="salary-embeddings"
+ROLE_NAME="${PROJECT}-role"
+KB_ROLE_NAME="${PROJECT}-kb-role"
+KB_NAME="${PROJECT}-salary-kb"
+SNS_TOPIC_NAME="${PROJECT}-notifications"
+WORKFLOW_NAME="loan_approval_agent"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EMBEDDING_MODEL_ARN="arn:aws:bedrock:${REGION}::foundation-model/amazon.titan-embed-text-v2:0"
+
+# Select regional inference profile based on region
+case "${REGION}" in
+  eu-*) INFERENCE_PROFILE_PREFIX="eu" ;;
+  ap-*) INFERENCE_PROFILE_PREFIX="ap" ;;
+  us-*) INFERENCE_PROFILE_PREFIX="us" ;;
+  sa-*) INFERENCE_PROFILE_PREFIX="sa" ;;
+  ca-*) INFERENCE_PROFILE_PREFIX="ca" ;;
+  af-*) INFERENCE_PROFILE_PREFIX="af" ;;
+  *)    INFERENCE_PROFILE_PREFIX="us" ;;
+esac
+INFERENCE_PROFILE="${INFERENCE_PROFILE_PREFIX}.anthropic.claude-sonnet-4-20250514-v1:0"
+INFERENCE_MODEL_ARN="arn:aws:bedrock:${REGION}::inference-profile/${INFERENCE_PROFILE}"
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║       AI Loan Approval Agent — MWAA Serverless          ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+echo "Region:     ${REGION}"
+echo "Account:    ${ACCOUNT_ID}"
+echo "S3 Bucket:  ${S3_BUCKET}"
+echo ""
+
+# ─── 1. Create S3 Bucket ────────────────────────────────────────
+echo "▸ Creating S3 bucket..."
+if aws s3api head-bucket --bucket "${S3_BUCKET}" 2>/dev/null; then
+  echo "  Bucket already exists, skipping."
+else
+  if [ "${REGION}" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "${S3_BUCKET}" --region "${REGION}" --output text > /dev/null
+  else
+    aws s3api create-bucket --bucket "${S3_BUCKET}" --region "${REGION}" \
+      --create-bucket-configuration LocationConstraint="${REGION}" --output text > /dev/null
+  fi
+  aws s3api put-public-access-block --bucket "${S3_BUCKET}" \
+    --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+  aws s3api put-bucket-versioning --bucket "${S3_BUCKET}" \
+    --versioning-configuration Status=Enabled
+  echo "  ✓ Bucket created."
+fi
+
+# ─── 2. Upload salary data ──────────────────────────────────────
+echo "▸ Uploading salary data..."
+aws s3 sync "${SCRIPT_DIR}/salary-data/" "s3://${S3_BUCKET}/salary-data/" --quiet
+echo "  ✓ Salary data uploaded."
+
+# ─── 3. Create SNS Topic ────────────────────────────────────────
+echo "▸ Creating SNS topic..."
+SNS_TOPIC_ARN=$(aws sns create-topic --name "${SNS_TOPIC_NAME}" --query TopicArn --output text --region "${REGION}")
+echo "  ✓ SNS topic: ${SNS_TOPIC_ARN}"
+
+# ─── 4. Create S3 Vector Bucket & Index ─────────────────────────
+echo "▸ Creating S3 Vector Bucket..."
+aws s3vectors create-vector-bucket \
+  --vector-bucket-name "${VECTOR_BUCKET_NAME}" \
+  --region "${REGION}" > /dev/null 2>&1 || true
+VECTOR_BUCKET_ARN=$(aws s3vectors list-vector-buckets --region "${REGION}" \
+  --query "vectorBuckets[?vectorBucketName=='${VECTOR_BUCKET_NAME}'].vectorBucketArn | [0]" --output text)
+echo "  ✓ Vector bucket: ${VECTOR_BUCKET_ARN}"
+
+echo "▸ Creating Vector Index (dimension=1024 for Titan Embed v2)..."
+aws s3vectors create-index \
+  --vector-bucket-name "${VECTOR_BUCKET_NAME}" \
+  --index-name "${VECTOR_INDEX_NAME}" \
+  --data-type float32 \
+  --dimension 1024 \
+  --distance-metric cosine \
+  --region "${REGION}" > /dev/null 2>&1 || true
+VECTOR_INDEX_ARN=$(aws s3vectors list-indexes --vector-bucket-name "${VECTOR_BUCKET_NAME}" --region "${REGION}" \
+  --query "indexes[?indexName=='${VECTOR_INDEX_NAME}'].indexArn | [0]" --output text)
+echo "  ✓ Vector index: ${VECTOR_INDEX_ARN}"
+
+# ─── 5. Create Knowledge Base IAM Role ──────────────────────────
+echo "▸ Creating Knowledge Base IAM role..."
+KB_TRUST_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "bedrock.amazonaws.com"},
+    "Action": "sts:AssumeRole",
+    "Condition": {
+      "StringEquals": {"aws:SourceAccount": "'"${ACCOUNT_ID}"'"},
+      "ArnLike": {"aws:SourceArn": "arn:aws:bedrock:'"${REGION}"':'"${ACCOUNT_ID}"':knowledge-base/*"}
+    }
+  }]
+}'
+
+if aws iam get-role --role-name "${KB_ROLE_NAME}" 2>/dev/null; then
+  echo "  Role already exists, updating trust policy."
+  aws iam update-assume-role-policy \
+    --role-name "${KB_ROLE_NAME}" \
+    --policy-document "${KB_TRUST_POLICY}"
+  sleep 10
+else
+  aws iam create-role \
+    --role-name "${KB_ROLE_NAME}" \
+    --assume-role-policy-document "${KB_TRUST_POLICY}" \
+    --output text > /dev/null
+fi
+
+aws iam put-role-policy \
+  --role-name "${KB_ROLE_NAME}" \
+  --policy-name "${KB_ROLE_NAME}-policy" \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["bedrock:InvokeModel"],
+        "Resource": "'"${EMBEDDING_MODEL_ARN}"'"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:ListBucket"],
+        "Resource": [
+          "arn:aws:s3:::'"${S3_BUCKET}"'",
+          "arn:aws:s3:::'"${S3_BUCKET}"'/salary-data/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3vectors:CreateIndex",
+          "s3vectors:PutVectors",
+          "s3vectors:DeleteVectors",
+          "s3vectors:GetVectors",
+          "s3vectors:ListVectors",
+          "s3vectors:QueryVectors",
+          "s3vectors:DescribeIndex",
+          "s3vectors:ListIndexes",
+          "s3vectors:DescribeVectorBucket",
+          "s3vectors:ListVectorBuckets"
+        ],
+        "Resource": [
+          "'"${VECTOR_BUCKET_ARN}"'",
+          "'"${VECTOR_INDEX_ARN}"'"
+        ]
+      }
+    ]
+  }'
+
+KB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${KB_ROLE_NAME}"
+echo "  ✓ KB role: ${KB_ROLE_ARN}"
+echo "  Waiting for IAM role propagation..."
+sleep 10
+
+# ─── 6. Create Bedrock Knowledge Base ───────────────────────────
+echo "▸ Creating Bedrock Knowledge Base..."
+
+EXISTING_KB_ID=$(aws bedrock-agent list-knowledge-bases \
+  --query "knowledgeBaseSummaries[?name=='${KB_NAME}'].knowledgeBaseId | [0]" \
+  --output text --region "${REGION}" 2>/dev/null || echo "None")
+
+if [ "${EXISTING_KB_ID}" != "None" ] && [ -n "${EXISTING_KB_ID}" ]; then
+  KB_ID="${EXISTING_KB_ID}"
+  echo "  Knowledge Base already exists: ${KB_ID}"
+else
+  KB_ID=$(aws bedrock-agent create-knowledge-base \
+    --name "${KB_NAME}" \
+    --description "Salary benchmark data for income verification in loan applications" \
+    --role-arn "${KB_ROLE_ARN}" \
+    --knowledge-base-configuration '{
+      "type": "VECTOR",
+      "vectorKnowledgeBaseConfiguration": {
+        "embeddingModelArn": "'"${EMBEDDING_MODEL_ARN}"'"
+      }
+    }' \
+    --storage-configuration '{
+      "type": "S3_VECTORS",
+      "s3VectorsConfiguration": {
+        "vectorBucketArn": "'"${VECTOR_BUCKET_ARN}"'",
+        "indexArn": "'"${VECTOR_INDEX_ARN}"'"
+      }
+    }' \
+    --query "knowledgeBase.knowledgeBaseId" \
+    --output text \
+    --region "${REGION}")
+  echo "  ✓ Knowledge Base created: ${KB_ID}"
+fi
+
+echo "  Waiting for Knowledge Base to become ACTIVE..."
+for i in $(seq 1 30); do
+  STATUS=$(aws bedrock-agent get-knowledge-base \
+    --knowledge-base-id "${KB_ID}" \
+    --query "knowledgeBase.status" \
+    --output text --region "${REGION}")
+  if [ "${STATUS}" = "ACTIVE" ]; then
+    echo "  ✓ Knowledge Base is ACTIVE."
+    break
+  fi
+  if [ "${STATUS}" = "FAILED" ]; then
+    echo "  ✗ Knowledge Base creation FAILED."
+    aws bedrock-agent get-knowledge-base --knowledge-base-id "${KB_ID}" --region "${REGION}"
+    exit 1
+  fi
+  echo "    Status: ${STATUS} (attempt ${i}/30)..."
+  sleep 10
+done
+
+# ─── 7. Create Data Source & Ingest ─────────────────────────────
+echo "▸ Creating data source and ingesting salary data..."
+
+EXISTING_DS_ID=$(aws bedrock-agent list-data-sources \
+  --knowledge-base-id "${KB_ID}" \
+  --query "dataSourceSummaries[0].dataSourceId" \
+  --output text --region "${REGION}" 2>/dev/null || echo "None")
+
+if [ "${EXISTING_DS_ID}" != "None" ] && [ -n "${EXISTING_DS_ID}" ]; then
+  DS_ID="${EXISTING_DS_ID}"
+  echo "  Data source already exists: ${DS_ID}"
+else
+  DS_ID=$(aws bedrock-agent create-data-source \
+    --knowledge-base-id "${KB_ID}" \
+    --name "salary-benchmarks" \
+    --data-source-configuration '{
+      "type": "S3",
+      "s3Configuration": {
+        "bucketArn": "arn:aws:s3:::'"${S3_BUCKET}"'",
+        "inclusionPrefixes": ["salary-data/"]
+      }
+    }' \
+    --query "dataSource.dataSourceId" \
+    --output text \
+    --region "${REGION}")
+  echo "  ✓ Data source created: ${DS_ID}"
+fi
+
+echo "  Starting ingestion job..."
+INGESTION_JOB_ID=$(aws bedrock-agent start-ingestion-job \
+  --knowledge-base-id "${KB_ID}" \
+  --data-source-id "${DS_ID}" \
+  --query "ingestionJob.ingestionJobId" \
+  --output text \
+  --region "${REGION}")
+
+echo "  Waiting for ingestion to complete..."
+for i in $(seq 1 30); do
+  ING_STATUS=$(aws bedrock-agent get-ingestion-job \
+    --knowledge-base-id "${KB_ID}" \
+    --data-source-id "${DS_ID}" \
+    --ingestion-job-id "${INGESTION_JOB_ID}" \
+    --query "ingestionJob.status" \
+    --output text --region "${REGION}")
+  if [ "${ING_STATUS}" = "COMPLETE" ]; then
+    echo "  ✓ Ingestion complete."
+    break
+  elif [ "${ING_STATUS}" = "FAILED" ]; then
+    echo "  ✗ Ingestion failed."
+    aws bedrock-agent get-ingestion-job \
+      --knowledge-base-id "${KB_ID}" \
+      --data-source-id "${DS_ID}" \
+      --ingestion-job-id "${INGESTION_JOB_ID}" \
+      --region "${REGION}"
+    exit 1
+  fi
+  echo "    Ingestion status: ${ING_STATUS} (attempt ${i}/30)..."
+  sleep 10
+done
+
+# ─── 8. Create MWAA Serverless Execution Role ───────────────────
+echo "▸ Creating MWAA Serverless execution role..."
+
+if aws iam get-role --role-name "${ROLE_NAME}" 2>/dev/null; then
+  echo "  Role already exists, updating policy."
+else
+  aws iam create-role \
+    --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document file://"${SCRIPT_DIR}/trust-policy.json" \
+    --output text > /dev/null
+fi
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+aws iam put-role-policy \
+  --role-name "${ROLE_NAME}" \
+  --policy-name "${ROLE_NAME}-policy" \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "CloudWatchLogs",
+        "Effect": "Allow",
+        "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        "Resource": "*"
+      },
+      {
+        "Sid": "BedrockInvoke",
+        "Effect": "Allow",
+        "Action": ["bedrock:InvokeModel"],
+        "Resource": [
+          "arn:aws:bedrock:'"${REGION}"':'"${ACCOUNT_ID}"':inference-profile/'"${INFERENCE_PROFILE}"'",
+          "arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0"
+        ]
+      },
+      {
+        "Sid": "BedrockRAG",
+        "Effect": "Allow",
+        "Action": ["bedrock:Retrieve", "bedrock:RetrieveAndGenerate"],
+        "Resource": "arn:aws:bedrock:'"${REGION}"':'"${ACCOUNT_ID}"':knowledge-base/'"${KB_ID}"'"
+      },
+      {
+        "Sid": "SNSPublish",
+        "Effect": "Allow",
+        "Action": ["sns:Publish"],
+        "Resource": "'"${SNS_TOPIC_ARN}"'"
+      },
+      {
+        "Sid": "S3Access",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+        "Resource": [
+          "arn:aws:s3:::'"${S3_BUCKET}"'",
+          "arn:aws:s3:::'"${S3_BUCKET}"'/*"
+        ]
+      }
+    ]
+  }'
+
+echo "  ✓ Execution role: ${ROLE_ARN}"
+sleep 10
+
+# ─── 9. Render & Upload Workflow YAML ────────────────────────────
+echo "▸ Rendering and uploading workflow..."
+
+sed -e "s|\${KNOWLEDGE_BASE_ID}|${KB_ID}|g" \
+    -e "s|\${SNS_TOPIC_ARN}|${SNS_TOPIC_ARN}|g" \
+    -e "s|\${S3_BUCKET}|${S3_BUCKET}|g" \
+    -e "s|\${INFERENCE_PROFILE}|${INFERENCE_PROFILE}|g" \
+    "${SCRIPT_DIR}/../loan_approval_agent.yaml" > /tmp/loan_approval_agent.yaml
+
+aws s3 cp /tmp/loan_approval_agent.yaml \
+  "s3://${S3_BUCKET}/yaml/loan_approval_agent.yaml" --quiet
+echo "  ✓ Workflow uploaded."
+
+# ─── 10. Create MWAA Serverless Workflow ─────────────────────────
+echo "▸ Creating MWAA Serverless workflow..."
+
+WORKFLOW_ARN=$(aws mwaa-serverless create-workflow \
+  --name "${WORKFLOW_NAME}" \
+  --definition-s3-location "{\"Bucket\":\"${S3_BUCKET}\",\"ObjectKey\":\"yaml/loan_approval_agent.yaml\"}" \
+  --role-arn "${ROLE_ARN}" \
+  --region "${REGION}" \
+  --query "WorkflowArn" \
+  --output text 2>&1) || true
+
+if echo "${WORKFLOW_ARN}" | grep -q "ConflictException\|already exists"; then
+  echo "  Workflow already exists, updating..."
+  WORKFLOW_ARN=$(aws mwaa-serverless list-workflows \
+    --query "Workflows[?contains(WorkflowArn, '${WORKFLOW_NAME}')].WorkflowArn | [0]" \
+    --output text --region "${REGION}")
+  aws mwaa-serverless update-workflow \
+    --workflow-arn "${WORKFLOW_ARN}" \
+    --definition-s3-location "{\"Bucket\":\"${S3_BUCKET}\",\"ObjectKey\":\"yaml/loan_approval_agent.yaml\"}" \
+    --role-arn "${ROLE_ARN}" \
+    --region "${REGION}" > /dev/null
+fi
+
+echo "  ✓ Workflow ARN: ${WORKFLOW_ARN}"
+
+# ─── Done ────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║                    Setup Complete!                       ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+echo "Run a loan application:"
+echo ""
+echo "  aws mwaa-serverless start-workflow-run \\"
+echo "    --workflow-arn ${WORKFLOW_ARN} \\"
+echo "    --override-parameters '{\"applicant_name\":\"Jane Doe\",\"occupation\":\"software_engineer\",\"yearly_income\":95000,\"loan_amount\":350000}' \\"
+echo "    --region ${REGION}"
+echo ""
+echo "Check status:"
+echo ""
+echo "  aws mwaa-serverless get-workflow-run \\"
+echo "    --workflow-arn ${WORKFLOW_ARN} \\"
+echo "    --run-id <RUN_ID> \\"
+echo "    --region ${REGION}"
+echo ""

--- a/serverless/usecases/loan-approval-agent/setup/salary-data/accountant.txt
+++ b/serverless/usecases/loan-approval-agent/setup/salary-data/accountant.txt
@@ -1,0 +1,19 @@
+Occupation: Accountant / CPA
+Industry: Finance and Professional Services
+
+Salary Ranges (United States, Annual):
+- Entry Level / Staff Accountant (0-2 years): $50,000 - $65,000
+- Senior Accountant (3-5 years): $65,000 - $90,000
+- Manager (6-10 years): $85,000 - $130,000
+- Director/Controller (10+ years): $120,000 - $200,000
+
+Verification Notes:
+- CPA certification typically adds 10-15% to salary
+- Big Four firms pay at the higher end of ranges
+- Busy season overtime is common but usually salaried (no overtime pay)
+- Self-employed CPAs may have variable income; look for 2-3 year average
+
+Red Flags for Income Verification:
+- Staff accountant claiming over $100,000 without manager title
+- Self-employed income claims without tax return documentation
+- Significant year-over-year income swings without explanation

--- a/serverless/usecases/loan-approval-agent/setup/salary-data/nurse.txt
+++ b/serverless/usecases/loan-approval-agent/setup/salary-data/nurse.txt
@@ -1,0 +1,19 @@
+Occupation: Registered Nurse (RN)
+Industry: Healthcare
+
+Salary Ranges (United States, Annual):
+- Entry Level (0-2 years): $55,000 - $70,000
+- Mid Level (3-7 years): $70,000 - $90,000
+- Senior/Specialist (8-15 years): $85,000 - $120,000
+- Nurse Practitioner (NP): $100,000 - $150,000
+
+Verification Notes:
+- Overtime and shift differentials can add 15-30% to base salary
+- Travel nurses may earn 1.5x-2x standard rates on temporary contracts
+- California, New York, and Massachusetts tend to be highest-paying states
+- Union positions may have publicly verifiable pay scales
+
+Red Flags for Income Verification:
+- Claimed salary exceeding NP range without advanced degree
+- Entry-level nurse claiming over $100,000 without travel/overtime explanation
+- Income inconsistent with geographic region cost of living

--- a/serverless/usecases/loan-approval-agent/setup/salary-data/sales_manager.txt
+++ b/serverless/usecases/loan-approval-agent/setup/salary-data/sales_manager.txt
@@ -1,0 +1,20 @@
+Occupation: Sales Manager
+Industry: Various (Technology, Retail, Manufacturing, Pharma)
+
+Salary Ranges (United States, Annual):
+- Entry Level / Inside Sales Rep (0-2 years): $40,000 - $60,000 base + commission
+- Account Executive (3-5 years): $60,000 - $90,000 base + commission
+- Sales Manager (5-10 years): $80,000 - $140,000 base + commission
+- VP of Sales / Director (10+ years): $130,000 - $250,000 base + commission
+
+Verification Notes:
+- On-target earnings (OTE) typically 1.5x-2x base salary
+- Commission structures vary widely; verify with employer or pay stubs
+- Technology sales tends to pay highest; retail lowest
+- Variable compensation makes income verification more complex
+
+Red Flags for Income Verification:
+- Claimed OTE without documentation of commission structure
+- Base salary above VP range without C-suite title
+- Inconsistent income across years without explanation of role change
+- Commission-only roles with no base salary documentation

--- a/serverless/usecases/loan-approval-agent/setup/salary-data/software_engineer.txt
+++ b/serverless/usecases/loan-approval-agent/setup/salary-data/software_engineer.txt
@@ -1,0 +1,19 @@
+Occupation: Software Engineer
+Industry: Technology
+
+Salary Ranges (United States, Annual):
+- Entry Level (0-2 years): $70,000 - $110,000
+- Mid Level (3-5 years): $110,000 - $160,000
+- Senior Level (6-10 years): $150,000 - $220,000
+- Staff/Principal (10+ years): $200,000 - $350,000
+
+Verification Notes:
+- Total compensation may include stock options and bonuses (20-40% of base)
+- Remote roles may have geographic pay adjustments
+- Contractors typically earn 1.3x-1.5x equivalent salary without benefits
+- FAANG and top-tier companies may exceed upper ranges by 30-50%
+
+Red Flags for Income Verification:
+- Claimed salary below entry level range with 5+ years experience
+- Claimed salary above principal range without executive title
+- Self-reported income without W-2 or pay stub documentation

--- a/serverless/usecases/loan-approval-agent/setup/salary-data/teacher.txt
+++ b/serverless/usecases/loan-approval-agent/setup/salary-data/teacher.txt
@@ -1,0 +1,19 @@
+Occupation: Teacher (K-12)
+Industry: Education
+
+Salary Ranges (United States, Annual):
+- Entry Level (0-3 years): $35,000 - $50,000
+- Mid Level (4-10 years): $45,000 - $65,000
+- Senior/Department Head (10-20 years): $55,000 - $85,000
+- Administration (Principal/VP): $75,000 - $120,000
+
+Verification Notes:
+- Public school salaries are often publicly available through district records
+- Summer tutoring or adjunct teaching can supplement income by $5,000-$15,000
+- Masters degree typically adds $5,000-$10,000 to base salary
+- Private school salaries may differ significantly from public scales
+
+Red Flags for Income Verification:
+- Claimed salary above $90,000 for classroom teacher without admin role
+- Income claims inconsistent with district published pay scales
+- Supplemental income exceeding 30% of base without documentation

--- a/serverless/usecases/loan-approval-agent/setup/teardown.sh
+++ b/serverless/usecases/loan-approval-agent/setup/teardown.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+
+# ─── Configuration ───────────────────────────────────────────────
+PROJECT="mwaa-loan-approval"
+REGION="${1:-${AWS_REGION:-us-east-1}}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+S3_BUCKET="${PROJECT}-${ACCOUNT_ID}-${REGION}"
+ROLE_NAME="${PROJECT}-role"
+KB_ROLE_NAME="${PROJECT}-kb-role"
+KB_NAME="${PROJECT}-salary-kb"
+SNS_TOPIC_NAME="${PROJECT}-notifications"
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║       AI Loan Approval Agent — Teardown                 ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ─── 1. Delete MWAA Serverless Workflow ──────────────────────────
+echo "▸ Deleting MWAA Serverless workflows..."
+WORKFLOW_ARNS=$(aws mwaa-serverless list-workflows \
+  --query "Workflows[?contains(WorkflowArn, 'loan_approval')].WorkflowArn" \
+  --output text --region "${REGION}" 2>/dev/null || echo "")
+
+for arn in ${WORKFLOW_ARNS}; do
+  echo "  Deleting ${arn}..."
+  aws mwaa-serverless delete-workflow --workflow-arn "${arn}" --region "${REGION}" 2>/dev/null || true
+done
+echo "  ✓ Workflows deleted."
+
+# ─── 2. Delete Knowledge Base ────────────────────────────────────
+echo "▸ Deleting Knowledge Base..."
+KB_ID=$(aws bedrock-agent list-knowledge-bases \
+  --query "knowledgeBaseSummaries[?name=='${KB_NAME}'].knowledgeBaseId | [0]" \
+  --output text --region "${REGION}" 2>/dev/null || echo "None")
+
+if [ "${KB_ID}" != "None" ] && [ -n "${KB_ID}" ]; then
+  # Delete data sources first
+  DS_IDS=$(aws bedrock-agent list-data-sources \
+    --knowledge-base-id "${KB_ID}" \
+    --query "dataSourceSummaries[].dataSourceId" \
+    --output text --region "${REGION}" 2>/dev/null || echo "")
+  for ds_id in ${DS_IDS}; do
+    aws bedrock-agent delete-data-source \
+      --knowledge-base-id "${KB_ID}" \
+      --data-source-id "${ds_id}" \
+      --region "${REGION}" 2>/dev/null || true
+  done
+  aws bedrock-agent delete-knowledge-base \
+    --knowledge-base-id "${KB_ID}" \
+    --region "${REGION}" 2>/dev/null || true
+  echo "  ✓ Knowledge Base deleted."
+else
+  echo "  No Knowledge Base found."
+fi
+
+# ─── 3. Delete SNS Topic ────────────────────────────────────────
+echo "▸ Deleting SNS topic..."
+SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${SNS_TOPIC_NAME}"
+aws sns delete-topic --topic-arn "${SNS_TOPIC_ARN}" --region "${REGION}" 2>/dev/null || true
+echo "  ✓ SNS topic deleted."
+
+# ─── 4. Delete IAM Roles ────────────────────────────────────────
+echo "▸ Deleting IAM roles..."
+for role in "${ROLE_NAME}" "${KB_ROLE_NAME}"; do
+  POLICIES=$(aws iam list-role-policies --role-name "${role}" --query "PolicyNames" --output text 2>/dev/null || echo "")
+  for policy in ${POLICIES}; do
+    aws iam delete-role-policy --role-name "${role}" --policy-name "${policy}" 2>/dev/null || true
+  done
+  aws iam delete-role --role-name "${role}" 2>/dev/null || true
+done
+echo "  ✓ IAM roles deleted."
+
+# ─── 5. Delete S3 Vector Bucket ──────────────────────────────────
+echo "▸ Deleting S3 Vector Bucket..."
+VECTOR_BUCKET_NAME="${PROJECT}-vectors"
+VECTOR_INDEX_NAME="salary-embeddings"
+aws s3vectors delete-index \
+  --vector-bucket-name "${VECTOR_BUCKET_NAME}" \
+  --index-name "${VECTOR_INDEX_NAME}" \
+  --region "${REGION}" 2>/dev/null || true
+aws s3vectors delete-vector-bucket \
+  --vector-bucket-name "${VECTOR_BUCKET_NAME}" \
+  --region "${REGION}" 2>/dev/null || true
+echo "  ✓ Vector bucket deleted."
+
+# ─── 6. Delete S3 Bucket ────────────────────────────────────────
+echo "▸ Deleting S3 bucket..."
+if aws s3api head-bucket --bucket "${S3_BUCKET}" 2>/dev/null; then
+  # Delete all object versions (required for versioned buckets)
+  aws s3api list-object-versions --bucket "${S3_BUCKET}" --region "${REGION}" --output json 2>/dev/null | \
+  python3 -c "
+import sys, json, subprocess
+data = json.load(sys.stdin)
+objects = []
+for v in data.get('Versions', []):
+    objects.append({'Key': v['Key'], 'VersionId': v['VersionId']})
+for d in data.get('DeleteMarkers', []):
+    objects.append({'Key': d['Key'], 'VersionId': d['VersionId']})
+if objects:
+    for i in range(0, len(objects), 1000):
+        batch = objects[i:i+1000]
+        subprocess.run(['aws', 's3api', 'delete-objects', '--bucket', '${S3_BUCKET}', '--delete', json.dumps({'Objects': batch, 'Quiet': True}), '--region', '${REGION}'], capture_output=True)
+    print(f'  Deleted {len(objects)} object versions')
+"
+  aws s3api delete-bucket --bucket "${S3_BUCKET}" --region "${REGION}" 2>/dev/null || true
+  echo "  ✓ S3 bucket deleted."
+else
+  echo "  No bucket found."
+fi
+
+echo ""
+echo "✓ Teardown complete."

--- a/serverless/usecases/loan-approval-agent/setup/trust-policy.json
+++ b/serverless/usecases/loan-approval-agent/setup/trust-policy.json
@@ -1,0 +1,35 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "airflow-serverless.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "AllowAirflowServerlessAssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "airflow-serverless.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "${aws:PrincipalAccount}"
+        },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:*:*:${aws:PrincipalAccount}:workflow/*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "bedrock.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an agentic AI workflow that processes loan applications using parallel AI agents for due diligence and income verification, then makes an automated approval decision.

### What's included

- **MWAA Serverless YAML workflow** — three Bedrock-powered agents (due diligence, income verification via RAG, final decision) with SNS notification and S3 audit logging
- **Provisioned Python DAG** — equivalent DAG for traditional MWAA environments using Airflow Variables
- **One-command deploy/teardown scripts** — creates S3 bucket, S3 Vectors, Bedrock Knowledge Base with salary benchmarks, SNS topic, IAM roles, and the MWAA Serverless workflow
- **Multi-region support** — uses regional inference profiles (us/eu/ap)

### Operators used

- \`BedrockInvokeModelOperator\` — risk assessment + final decision
- \`BedrockRaGOperator\` — income verification against salary benchmark Knowledge Base
- \`SnsPublishOperator\` — applicant notification
- \`S3CreateObjectOperator\` — audit trail

### Structure

\`\`\`
serverless/usecases/loan-approval-agent/
├── README.md
├── loan_approval_agent.yaml
├── provisioned/
│   └── loan_approval_agent_dag.py
└── setup/
    ├── deploy.sh
    ├── teardown.sh
    ├── trust-policy.json
    └── salary-data/
\`\`\`

### Testing

- Deployed and ran end-to-end in us-east-1
- All 5 tasks completed successfully (due_diligence → income_verification → loan_decision → notify_applicant + log_decision)
- Teardown script confirmed to clean up all resources