### PR TITLE
Fix MCP validator to reject non-dict params

### DIFF
--- a/serverless/mcp/src/tools.py
+++ b/serverless/mcp/src/tools.py
@@ -89,6 +89,11 @@ def validate_yaml(yaml_content: str) -> dict:
             if da_et is not None and _parse_duration_seconds(da_et) is None:
                 errors.append(f"DAG '{dag_key}': default_args.execution_timeout must match pattern ^\\d+[smhd]$")
 
+        # Params validation
+        params = dag_cfg.get("params")
+        if params is not None and not isinstance(params, dict):
+            errors.append(f"DAG '{dag_key}': 'params' must be a mapping, got {type(params).__name__}")
+
         # Tasks validation — schema says tasks is an array
         tasks = dag_cfg["tasks"]
         if isinstance(tasks, list):


### PR DESCRIPTION
**Bug**: validate_yaml accepted params: '{}' (string literal) as valid, but MWAA Serverless rejects it at deploy time with ValidationException: Invalid params configuration.

**Fix**: Added type check — params must be a dict/mapping. String, list, or other types now produce a validation error.

**Note**: The generate_dag_yaml tool also has a limitation — it returns static templates and ignores the description/prompt content. That's a separate enhancement tracked separately.