### PR TITLE
Fix trigger table Fernet encryption; Add support for AF 2.10.x, 2.11 in start-stop solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ package-lock.json
 .AppleDouble
 .LSOverride
 __pycache__
+.aws-sam/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon Managed Workflows for Apache Airflow (MWAA) Examples
 
 This repository contains example DAGs, requirements.txt, plugins, and CloudFormation templates focused on Amazon MWAA.  Since Amazon MWAA is running open-source Apache Airflow many of the contributions will be applicable for self-managed implementations as well.
@@ -57,4 +63,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
-

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # mwaa-blueprints
 
 ## Description

--- a/blueprints/examples/AWSGlue/README.md
+++ b/blueprints/examples/AWSGlue/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Glue with MWAA
 
 This example is a quick start for orchestrating AWS Glue crawler and AWS Glue Job with MWAA

--- a/blueprints/examples/ECS/README.md
+++ b/blueprints/examples/ECS/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 # Orchestrating ECS Workload using MWAA
 

--- a/blueprints/examples/EKS/README.md
+++ b/blueprints/examples/EKS/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Orchestrating jobs in EKS
 
 ## Description
@@ -84,4 +90,3 @@ The following DAGs are included in the repo
 - *eks_run_pod:* runs a sample ```pod``` on the created ```EKS cluster```
 
 - *delete_eks_cluster_nodegroup:* deletes the previously created ```node group and EKS Cluster```
-

--- a/blueprints/examples/EKS/infra/cdk/README.md
+++ b/blueprints/examples/EKS/infra/cdk/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 # Welcome to your CDK Python project!
 

--- a/blueprints/examples/EMR/README.md
+++ b/blueprints/examples/EMR/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # EMR on EKS with MWAA
 
 This example deploys the following resources

--- a/blueprints/examples/EMR_on_EKS/README.md
+++ b/blueprints/examples/EMR_on_EKS/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # EMR on EKS with MWAA
 
 This example is a quick start for orchestrating EMR on EKS jobs with MWAA
@@ -100,4 +106,3 @@ export AWS_DEFAULT_REGION={region}
 make cdk-undeploy mwaa_bucket={MWAA_BUCKET} mwaa_execution_role_name=m{MWAA_EXEC_ROLE} mwaa_env_name={MWAA_ENV_NAME}
 ```
 ## Troubleshooting
-

--- a/blueprints/examples/Lambda/README.md
+++ b/blueprints/examples/Lambda/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Lambda with MWAA
 
 This example uses the [TLC Trip Record Data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) dataset. This example deploys the following resources:
@@ -204,4 +210,3 @@ DAG Task dependency:
     export DOCKER_BUILDKIT=0
     export COMPOSE_DOCKER_CLI_BUILD=0
     ```
-

--- a/blueprints/examples/Lambda/image/README.md
+++ b/blueprints/examples/Lambda/image/README.md
@@ -1,0 +1,6 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+

--- a/dags/airflow-243-examples/README.md
+++ b/dags/airflow-243-examples/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon Managed Workflows for Apache Airflow (MWAA) using Apache Airflow 2.4.3 Examples
 
 This examples in this directory demonstrates how to use the below new features of Apache Airflow 2.4.3 in an Amazon MWAA environment:

--- a/dags/airflow-243-examples/data_aware_scheduling_datasets/README.md
+++ b/dags/airflow-243-examples/data_aware_scheduling_datasets/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon Managed Workflows for Apache Airflow (MWAA) CloudFormation Templates
 
 Example CloudFormation templates for Amazon MWAA.  See [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html) for details.

--- a/dags/airflow-243-examples/dynamic_task_mapping/README.md
+++ b/dags/airflow-243-examples/dynamic_task_mapping/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon Managed Workflows for Apache Airflow (MWAA) CloudFormation Templates
 
 Example CloudFormation templates for Amazon MWAA.  See [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html) for details.

--- a/dags/airflow-243-examples/python_version_checker/README.md
+++ b/dags/airflow-243-examples/python_version_checker/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon Managed Workflows for Apache Airflow (MWAA) CloudFormation Templates
 
 Example CloudFormation templates for Amazon MWAA.  See [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html) for details.

--- a/dags/airflow-272-examples/README.md
+++ b/dags/airflow-272-examples/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Examples for Amazon Managed Workflows for Apache Airflow (Amazon MWAA) using Apache Airflow 2.7.2
 
 The examples in this directory demonstrate how to use the following new features of Apache Airflow 2.7.2 in an Amazon MWAA environment:

--- a/dags/airflow-272-examples/deferrable_operators/README.md
+++ b/dags/airflow-272-examples/deferrable_operators/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Using deferrable operators in Amazon Managed Workflows for Apache Airflow
 
 Using deferrable operators in Amazon MWAA requires the following:

--- a/dags/airflow-272-examples/setup_teardown_tasks/README.md
+++ b/dags/airflow-272-examples/setup_teardown_tasks/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Using setup and teardown operators in Amazon Managed Workflows for Apache Airflow
 
 Using setup and teardown operators in Amazon MWAA requires the following:

--- a/dags/airflow-306-examples/README.md
+++ b/dags/airflow-306-examples/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Airflow 3.0.6 Examples for Amazon MWAA
 
 This directory contains example Apache Airflow 3.0.6 DAGs demonstrating integration with various AWS services. These examples are designed to work with Amazon Managed Workflows for Apache Airflow (MWAA) and showcase best practices for workflow orchestration.

--- a/dags/bash_operator_script/README.md
+++ b/dags/bash_operator_script/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Interactive Commands with Amazon Managed Workflows for Apache Airflow (MWAA) and Bash Operator
 This script serves as an example of how to run a bash operator in Amazon MWAA programmatically using the MWAA CLI API. This can be useful for debugging plugins or dependencies. 
 
@@ -164,4 +170,3 @@ See [CONTRIBUTING](../../blob/main/CONTRIBUTING.md#security-issue-notifications)
 ## License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](../../blob/main/LICENSE) file.
-

--- a/dags/duplicate_role/README.md
+++ b/dags/duplicate_role/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Amazon Managed Workflows for Apache Airflow (MWAA) Duplicate Role
 
 Duplicates an existing RBAC role and assigns to a user
@@ -29,4 +35,3 @@ See [CONTRIBUTING](../../blob/main/CONTRIBUTING.md#security-issue-notifications)
 ## License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](../../blob/main/LICENSE) file.
-

--- a/dags/emr_job/README.md
+++ b/dags/emr_job/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Amazon Managed Workflows for Apache Airflow (MWAA) and Amazon EMR
 
 Use Amazon Managed Workflows for Apache Airflow (MWAA) to design and run a serverless workflow that coordinates Amazon Elastic Map Reduce (EMR) jobs. Amazon EMR is the industry-leading cloud big data platform for processing vast amounts of data using open source tools such as Apache Spark, Apache Hive, Apache HBase, Apache Flink, Apache Hudi, and Presto.
@@ -152,4 +158,3 @@ See [CONTRIBUTING](../../blob/main/CONTRIBUTING.md#security-issue-notifications)
 ## License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](../../blob/main/LICENSE) file.
-

--- a/dags/get_dag_id/README.md
+++ b/dags/get_dag_id/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Amazon Managed Workflows for Apache Airflow (MWAA) Get DAG ID
 
 If the dag parse is in the context of a DAG execution, this function will return the DAG ID.  

--- a/dags/metadb_to_secrets_manager/README.md
+++ b/dags/metadb_to_secrets_manager/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Move your Apache Airflow Connections and Variables to AWS Secrets Manager
 
 This example reads from an existing Metadatabase and copies all connections and variables to AWS Secrets Manager
@@ -123,4 +129,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
-

--- a/dags/xgboost-ml-pipeline/README.md
+++ b/dags/xgboost-ml-pipeline/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Orchestrate XGBoost ML Pipelines with Managed Workflows for Apache Airflow
 
 This example demonstrates how to orchestrate an ML pipeline that uses Glue to preprocess a dataset and the XGBoost algorithm in Sagemaker to train a model and deploy an endpoint.
@@ -247,4 +253,3 @@ See [CONTRIBUTING](/CONTRIBUTING.md#security-issue-notifications) for more infor
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
-

--- a/infra/cloudformation/README.md
+++ b/infra/cloudformation/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 # Welcome to your MWAA Cloudformation project!
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 # Welcome to your MWAA Terrafom project!
 

--- a/requirements/amazon_backport/README.md
+++ b/requirements/amazon_backport/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Amazon Managed Workflows for Apache Airflow (MWAA) and Backport Providers
 
 Use Amazon Managed Workflows for Apache Airflow (MWAA) with Apache Airflow Amazon backport providers.
@@ -28,4 +34,3 @@ See [CONTRIBUTING](../../blob/main/CONTRIBUTING.md#security-issue-notifications)
 ## License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](../../blob/main/LICENSE) file.
-

--- a/requirements/gcp_backport/README.md
+++ b/requirements/gcp_backport/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ### Amazon Managed Workflows for Apache Airflow (MWAA) and GCP Backport Providers
 
 Use Amazon Managed Workflows for Apache Airflow (MWAA) with Apache Airflow GCP backport providers.
@@ -33,4 +39,3 @@ See [CONTRIBUTING](../../blob/main/CONTRIBUTING.md#security-issue-notifications)
 ## License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](../../LICENSE) file.
-

--- a/serverless/examples/README.md
+++ b/serverless/examples/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # MWAA Serverless Example DAGs
 
 This directory contains 29 example MWAA Serverless DAGs — one for each supported AWS service. Every DAG is **self-contained**: it provisions its own resources via CloudFormation, runs the service operations, and cleans up afterward.

--- a/serverless/mcp/README.md
+++ b/serverless/mcp/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # MWAA Serverless MCP Server
 
 MCP server on AWS Lambda that helps AI agents build, validate, convert, deploy, and operate MWAA Serverless workflows.

--- a/serverless/mwaa_serverless_metrics_dashboard/README.md
+++ b/serverless/mwaa_serverless_metrics_dashboard/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 
 ### MWAA Serverless Monitoring and observability

--- a/serverless/usecases/loan-approval-agent/README.md
+++ b/serverless/usecases/loan-approval-agent/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # AI Loan Approval Agent — MWAA Serverless
 
 An agentic AI workflow that processes loan applications using parallel AI agents for due diligence and income verification, then makes an automated approval decision.

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Apache Airflow use cases
 
 Complete set of sample use cases including documentation, infrastructure as code and dependant resources. Follow the README.md in each use cases to get started.

--- a/usecases/image-processing/README.md
+++ b/usecases/image-processing/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Airflow sample image processing pipeline with Airflow 1.10.12
 
 This is an Ariflow verion of image processing workflow in [workshop](https://image-processing.serverlessworkshops.io/)
@@ -84,5 +90,3 @@ aws rekognition delete-faces \
 ```
 
 <!-- aws s3 cp requirement.txt s3://{bucket_name}/requirement.txt -->
-
-

--- a/usecases/local-runner-on-ecs-fargate/cloudformation/README.md
+++ b/usecases/local-runner-on-ecs-fargate/cloudformation/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Deploy ECS and RDS Resources using CloudFormation
 This sample project helps creating MWAA Sandbox environment on ECS Fargate 
 

--- a/usecases/local-runner-on-ecs-fargate/terraform/README.md
+++ b/usecases/local-runner-on-ecs-fargate/terraform/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Deploy ECS and RDS Resources using Terraform
 This project gives instructions on how to setup the ECS and RDS resources 
 

--- a/usecases/metadata-migration/README.md
+++ b/usecases/metadata-migration/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Airflow sample migration scripts
 
 Metadata import and export scripts are now part of the [MWAA Disaster Recovery project](https://pypi.org/project/mwaa-dr/). 

--- a/usecases/mwaa-cognito-cdk/README.md
+++ b/usecases/mwaa-cognito-cdk/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Amazon MWAA deployment in private AWS VPC incorporated with Amazon Cognito Authentication using AWS CDKv2
 
 ## Summary

--- a/usecases/mwaa-dag-factory-example/README.md
+++ b/usecases/mwaa-dag-factory-example/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # MWAA Data Pipeline Workshop
 
 One-command deployment of a provisioned MWAA instance with DAG Factory installed. As part of this stack data pipeline with VPC, Redshift, Glue, and EMR Serverless.

--- a/usecases/mwaa-glue-athena/README.md
+++ b/usecases/mwaa-glue-athena/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 ## Amazon MWAA with AWS Glue and Amazon Athena
 
 ### Overview

--- a/usecases/mwaa-glue-bedrock/README.md
+++ b/usecases/mwaa-glue-bedrock/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 # Event-Driven Data Integration Powered by Amazon Managed Workflows for Apache Airflow (MWAA)
 

--- a/usecases/mwaa-observability-enhancement/README.md
+++ b/usecases/mwaa-observability-enhancement/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Improve Observability across MWAA tasks
 
 Observability across the different processes within the data pipeline is a key component to monitor the success and/or failure of the pipeline. While scheduling the execution of tasks within the data pipeline is controlled by Airflow, the execution of the task itself (transforming, normalizing and/or aggregating data) is done by different services based on the use case. Having an end-to-end view of the data flow is a challenge due to multiple touch points in the data pipeline.

--- a/usecases/mwaa-public-webserver-custom-domain/README.md
+++ b/usecases/mwaa-public-webserver-custom-domain/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # amazon-mwaa-custom-domain-public-endpoint
 
 Sample code to demonstrate using Amazon CloudFront, AWS Lambda@Edge, and Amazon Cognito to enable custom domain for a public MWAA deployment. This solution is built on code from samples repo below with minor updates.

--- a/usecases/mwaa-snowflake-integration/README.md
+++ b/usecases/mwaa-snowflake-integration/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Using Snowflake with Amazon MWAA for Orchestrating Data Pipelines
 
 Customers rely on data from different sources such as mobile applications, clickstream events from websites, historical data and more to deduce meaningful patterns in order to optimize their products, services and processes. Using a data pipeline, which is a set of tasks used to automate the movement and transformation of data between different systems can reduce the time and effort needed to gain insights from the data. Apache Airflow and Snowflake have emerged as powerful technologies for data management and analysis.
@@ -5,4 +11,3 @@ Customers rely on data from different sources such as mobile applications, click
 Amazon Managed Workflows for Apache Airflow (Amazon MWAA) is a managed workflow orchestration service for Apache Airflow that makes it simple to set up and operate end-to-end data pipelines in the cloud at scale. Snowflake Data Cloud platform provides a single source of truth for all your data needs and allows organizations to store, analyze and share large amounts of data with ease. The Apache Airflow open-source community provides over 1,000 pre-built operators (plugins that simplify connections to services) for Apache Airflow to build data pipelines. 
 
 Scripts in this Repo are based on [blog post](https://), where we provide an overview of orchestrating your data pipeline using Snowflake operators in your Amazon MWAA environment. We will define the steps needed to setup the integration between Amazon MWAA and Snowflake. The solution will provide an end-to-end automated workflow which includes data ingestion, transformation, analytics and consumption.
-

--- a/usecases/mwaa-with-codeartifact/README.md
+++ b/usecases/mwaa-with-codeartifact/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # Use AWS CodeArtifact with Amazon MWAA for Python dependencies
 
 This project demonstrates how to create an [Amazon MWAA](https://aws.amazon.com/managed-workflows-for-apache-airflow/) environment that uses [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) for Python dependencies. This enables users to avoid providing MWAA with an internet access via NAT Gateway and hence reduce the cost of their infrastructure.

--- a/usecases/mwaa_utilization_cw_metric/README.md
+++ b/usecases/mwaa_utilization_cw_metric/README.md
@@ -1,3 +1,9 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 # mwaa-custom-metrics
 
 This is a sample implementation for the [blog](). By running the Makefile you can create a VPC with NAT/IGW, MWAA environment, associated IAM roles, CW dashboard etc
@@ -14,4 +20,3 @@ Visit the [blog]() for instructions
 ## Considerations
 The listed metrics are just a few key metrics. Depending on your workload, you should be monitoring other metrics offerred in the AWS/MWAA namespace.
 Airflow metrics are logged in MWAA custom namespace. You can learn more about the metrics from [here](https://docs.aws.amazon.com/mwaa/latest/userguide/access-metrics-cw-202.html)
-

--- a/usecases/start-stop-mwaa-environment/README.md
+++ b/usecases/start-stop-mwaa-environment/README.md
@@ -10,7 +10,7 @@ These application solutions are not supported products in their own right, but e
 
 ![typescript](https://img.shields.io/badge/cdk-typescript-green)
 [![code style: eslint](https://img.shields.io/badge/code_style-eslint-orange.svg)](https://github.com/psf/black)
-![MWAA](https://img.shields.io/badge/MWAA-2.10.3_|_2.9.2_|_2.8.1_|_2.7.2_|_2.6.3_|_2.5.1_|_2.4.3_|_2.2.2_|_2.0.2-blue)
+![MWAA](https://img.shields.io/badge/MWAA-2.11.0_|_2.10.3_|_2.9.2_|_2.8.1_|_2.7.2_|_2.6.3_|_2.5.1_|_2.4.3_|_2.2.2_|_2.0.2-blue)
 <!-- TOC ignore:true -->
 # Contents
 

--- a/usecases/start-stop-mwaa-environment/README.md
+++ b/usecases/start-stop-mwaa-environment/README.md
@@ -1,10 +1,16 @@
+## Disclaimer
+
+AWS code samples are example code that demonstrates practical implementations of AWS services for specific use cases and scenarios.
+
+These application solutions are not supported products in their own right, but educational examples to help our customers use our products for their applications. As our customer, any applications you integrate these examples into should be thoroughly tested, secured, and optimized according to your business's security standards & policies before deploying to production or handling production workloads.
+
 
 <!-- TOC ignore:true -->
 # Automate Stopping and Starting an Amazon MWAA Environment
 
 ![typescript](https://img.shields.io/badge/cdk-typescript-green)
 [![code style: eslint](https://img.shields.io/badge/code_style-eslint-orange.svg)](https://github.com/psf/black)
-![MWAA](https://img.shields.io/badge/MWAA-2.9.2_|_2.8.1_|_2.7.2_|_2.6.3_|_2.5.1_|_2.4.3_|_2.2.2_|_2.0.2-blue)
+![MWAA](https://img.shields.io/badge/MWAA-2.10.3_|_2.9.2_|_2.8.1_|_2.7.2_|_2.6.3_|_2.5.1_|_2.4.3_|_2.2.2_|_2.0.2-blue)
 <!-- TOC ignore:true -->
 # Contents
 
@@ -39,6 +45,7 @@
     - [Pausing While Active](#pausing-while-active)
     - [Stopping and Starting Multiple MWAA Environments](#stopping-and-starting-multiple-mwaa-environments)
     - [Not All MetaData Tables are Backed Up](#not-all-metadata-tables-are-backed-up)
+    - [Trigger Table Excluded (Airflow 2.9.0+)](#trigger-table-excluded-airflow-290)
 
 <!-- /TOC -->
 
@@ -409,3 +416,20 @@ tables such as `dag_run`, `task_instance`, `log`, `task_fail`, `job`, `slot_pool
 and `variable` among others. Users should update the export and import DAG scripts for other
 tables in their metadata store. Here is the metadata schema documentation for Airflow
 [2.5.1](https://airflow.apache.org/docs/apache-airflow/2.5.1/database-erd-ref.html) for your reference.
+
+## Trigger Table Excluded (Airflow 2.9.0+)
+
+Starting in Apache Airflow 2.9.0, the `trigger` table's `kwargs` column is encrypted using
+Fernet with a key unique to each MWAA environment. This means trigger data exported from one
+environment cannot be decrypted by another environment, as each has its own Fernet key.
+
+Importing foreign-encrypted trigger rows into a different environment will cause the triggerer
+process to crash with `cryptography.fernet.InvalidToken`, which in turn terminates the
+scheduler and results in a sustained outage until the trigger table is manually cleaned.
+
+The `trigger` table is intentionally excluded from the export/import DAGs for version 2.9.2+.
+This has no functional impact on the start-stop solution because:
+
+- Triggers are ephemeral - they represent in-flight async waits for deferred tasks only.
+- They are recreated automatically when DAGs with deferrable operators run on the new environment.
+- In a proper stop scenario, no tasks should be actively deferred at export time.

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.10.x/mwaa_export_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.10.x/mwaa_export_data.py
@@ -1,0 +1,305 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from airflow import DAG, settings
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dummy import DummyOperator
+from airflow.utils.dates import days_ago
+from airflow.models import DAG
+from airflow.models import Variable, Connection
+from airflow.hooks.S3_hook import S3Hook
+from sqlalchemy import text
+import csv
+from io import StringIO
+import boto3
+import json
+
+
+"""
+The module iterates through the list of sql statement and table, reads data and stores in S3 as csv file.
+Before it exports the data, it copies all the active dags and pause the execution of all other DAG.
+"""
+# S3 prefix where the exported file are
+S3_KEY = 'data/'
+
+dag_id = 'mwaa_export_data'
+
+STATE_SUCCESS = 'success'
+STATE_RUNNING = 'running'
+
+# Avoids to export 'mwaa_export_data' dag as 'running' state because it behaves just like "catchup=True" and runs some duplicate tasks
+DAG_RUN_SELECT = f"select dag_id, clear_number, execution_date, state, run_id, external_trigger, \
+'\\x' || encode(conf,'hex') as conf, end_date, start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, \
+updated_at from dag_run where dag_id <> '{dag_id}' or state <> '{STATE_RUNNING}' \
+UNION \
+select dag_id, clear_number, execution_date, '{STATE_SUCCESS}' as state, run_id, external_trigger, \
+'\\x' || encode(conf,'hex') as conf, '{days_ago(0)}'::timestamp as end_date, start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, \
+updated_at from dag_run where dag_id = '{dag_id}' and state = '{STATE_RUNNING}' "
+
+TASK_INSTANCE_SELECT = "select task_id, dag_id, run_id, custom_operator_name, start_date, end_date, duration, state, task_display_name, \
+try_number, hostname, unixname, job_id, pool, queue, priority_weight, \
+operator, queued_dttm, rendered_map_index, pid, max_tries, '\\x' || encode(executor_config,'hex') as executor_config ,\
+pool_slots, queued_by_job_id, external_executor_id, trigger_id ,\
+trigger_timeout, next_method, next_kwargs, map_index, executor, updated_at from task_instance \
+where state NOT IN ('running','restarting','queued','scheduled', 'up_for_retry','up_for_reschedule')"
+
+LOG_SELECT = "select dttm, dag_id, task_id, event, execution_date, owner, owner_display_name, run_id, extra, try_number from log"
+
+TASK_FAIL_SELECT = "select task_id, dag_id, run_id, map_index, start_date, end_date, duration from task_fail"
+
+JOB_SELECT = "select dag_id,  state, job_type , start_date, \
+end_date, latest_heartbeat, executor_class, hostname, unixname from job"
+
+POOL_SLOTS = "select pool, slots, description, include_deferred from slot_pool where pool != 'default_pool'"
+
+# NOTE: The trigger table is intentionally excluded from export.
+# Starting in Airflow 2.9.0, trigger.kwargs is Fernet-encrypted with a per-environment key.
+# Exporting and importing these rows into a different environment causes
+# cryptography.fernet.InvalidToken errors that crash the triggerer and scheduler.
+# Triggers are ephemeral (in-flight async waits for deferred tasks) and are recreated
+# automatically when DAGs with deferrable operators run on the new environment.
+
+
+##################
+# Add more tables If you need
+##################
+
+
+# This object contains the statement to select and the table name
+# The data is exported to the S3 Bucket defined at the top.
+# Starting in v2.9.2, we are exculing dataset tables from imports as they are auto-generated
+
+##################
+# If you add newer tables, They need an entry here as well
+##################
+
+OBJECTS_TO_EXPORT = [
+    [DAG_RUN_SELECT, "dag_run"],
+    [TASK_INSTANCE_SELECT, "task_instance"],
+    [LOG_SELECT, "log"],
+    [TASK_FAIL_SELECT, "task_fail"],
+    [JOB_SELECT, "job"],
+    [POOL_SLOTS, "slot_pool"]
+]
+
+def stream_to_S3_fn(context, result, filename):
+    from smart_open import open
+
+    s3_file = f"s3://{get_s3_bucket(context)}/{S3_KEY}{filename}.csv"
+    # only get 10K rows at a time
+    REC_COUNT = 5000
+    outfileStr = ""
+    with open(s3_file, 'wb') as write_io:
+        while True:
+            chunk = result.fetchmany(REC_COUNT)
+            if not chunk:
+                break
+            f = StringIO(outfileStr)
+            w = csv.writer(f)
+            w.writerows(chunk)
+            write_io.write(f.getvalue().encode("utf8"))
+        write_io.close()
+
+# pause all active dags to have consistent and reliable copy of dag history exports
+def pause_dags():
+    session = settings.Session()
+    session.execute(
+        text(f"update dag set is_paused = true where dag_id != '{dag_id}';"))
+    session.commit()
+    session.close()
+
+
+# Exports all active dags to S3; This data is used to unpause the dag in the new environment
+def export_active_dags(**context):
+    session = settings.Session()
+    result = session.execute("select * from active_dags")
+    stream_to_S3_fn(context, result, 'active_dags')
+    session.close()
+
+
+# exports variable. Variable value is encrypted;
+# So, the method uses the Variable class to decrypt the value and exports the data
+def export_variable(**context):
+    session = settings.Session()
+    s3_hook = S3Hook()
+    s3_client = s3_hook.get_conn()
+    query = session.query(Variable)
+    allrows = query.all()
+    k = ["key", "val", "is_encrypted", "description"]
+    if len(allrows) > 0:
+        outfileStr = ""
+        f = StringIO(outfileStr)
+        w = csv.DictWriter(f,  k)
+        for y in allrows:
+            w.writerow({k[0]: y.key, k[1]: y.get_val(),
+                       k[2]: y.is_encrypted, k[3]: None})
+        outkey = S3_KEY + 'variable.csv'
+        s3_client.put_object(Bucket=get_s3_bucket(context), Key=outkey, Body=f.getvalue())
+    session.close()
+
+    return "OK"
+
+def export_connection(**context):
+    session = settings.Session()
+    s3_hook = S3Hook()
+    s3_client = s3_hook.get_conn()
+    query = session.query(Connection)
+    allrows = query.all()
+    k = ["conn_id", "conn_type", "host", "schema","login","password","port","extra","is_encrypted","is_extra_encrypted","description"]
+    if len(allrows) > 0:
+        outfileStr = ""
+        f = StringIO(outfileStr)
+        w = csv.DictWriter(f,  k)
+        for y in allrows:
+
+
+            w.writerow({k[0]: y.conn_id, k[1]: y.conn_type, k[2]: y.description, k[3]: y.host,
+                        k[4]: y.login, k[5]: y.get_password(),k[6]: y.schema, k[7]: y.port,
+                        k[8]: y.get_extra()})
+
+        outkey = S3_KEY + 'connection.csv'
+        s3_client.put_object(Bucket=get_s3_bucket(context), Key=outkey, Body=f.getvalue())
+    session.close()
+
+    return "OK"
+
+
+# backsup the active dags before pausing them
+def back_up_activedags():
+    session = settings.Session()
+    session.execute(text(f"drop table if exists active_dags;"))
+    session.execute(text(
+        f"create table active_dags as select dag_id from dag where not is_paused and is_active;"))
+    session.commit()
+    session.close()
+
+# Activate dags
+def activate_dags():
+    session = settings.Session()
+    conn = settings.engine.raw_connection()
+    try:
+        session.execute(text(f"UPDATE dag d SET is_paused=false FROM active_dags ed WHERE d.dag_id = ed.dag_id;"))
+        session.execute(text(f"drop table active_dags;"))
+        session.commit()
+    finally:
+        conn.close()
+
+
+# iterate OBJECTS_TO_EXPORT and call export
+def export_data(**context):
+    session = settings.Session()
+
+    for x in OBJECTS_TO_EXPORT:
+        result = session.execute(text(x[0]))
+        stream_to_S3_fn(context, result, x[1])
+
+    session.close()
+    return "OK"
+
+
+# Export Failure/Success notification
+def get_s3_bucket(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['bucket']
+
+
+def get_task_token(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['taskToken']
+
+
+def get_dag_run_result(context):
+    dag_run = context.get('dag_run')
+    task_instances = dag_run.get_task_instances()
+    task_states = []
+    for task in task_instances:
+        task_states.append(f'{task.task_id} => {task.state}')
+    return {'dag': dag_run.dag_id, 'dag_run': dag_run.run_id, 'tasks': task_states}
+
+
+def notify_success(**context):
+    result = get_dag_run_result(context)
+    result['location'] = f's3://{get_s3_bucket(context)}/{S3_KEY}'
+    result['status'] = 'Success'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_success(taskToken=token, output=json.dumps(result))
+
+
+def notify_failure(context):
+    result = get_dag_run_result(context)
+    result['status'] = 'Fail'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_failure(taskToken=token, error='Export Error', cause=json.dumps(result))
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'on_failure_callback': notify_failure
+}
+with DAG(dag_id=dag_id, schedule_interval=None, catchup=False, default_args=default_args) as dag:
+
+    back_up_activedags_t = PythonOperator(
+        task_id="back_up_activedags",
+        python_callable=back_up_activedags
+    )
+    pause_dags_t = PythonOperator(
+        task_id="pause_dags",
+        python_callable=pause_dags
+    )
+    export_active_dags_t = PythonOperator(
+        task_id="export_active_dags",
+        python_callable=export_active_dags,
+        provide_context=True
+    )
+    export_variable_t = PythonOperator(
+        task_id="export_variable",
+        python_callable=export_variable,
+        provide_context=True
+    )
+
+    export_data_t = PythonOperator(
+        task_id="export_data",
+        python_callable=export_data,
+        provide_context=True
+    )
+    export_connection_t = PythonOperator(
+        task_id="export_connection",
+        python_callable=export_connection,
+        provide_context=True
+    )
+
+    clean_up_t = DummyOperator(task_id='clean_up')
+
+    notify_success_t = PythonOperator(
+        task_id='notify_success',
+        python_callable=notify_success,
+        provide_context=True
+    )
+
+    activate_dags_on_failure_t = PythonOperator(
+        task_id="activate_dags_on_failure",
+        python_callable=activate_dags,
+        trigger_rule="one_failed"
+    )
+
+    back_up_activedags_t >> pause_dags_t >> [export_data_t, export_active_dags_t, export_variable_t, export_connection_t] >> clean_up_t >> [activate_dags_on_failure_t, notify_success_t]

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.10.x/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.10.x/mwaa_import_data.py
@@ -1,0 +1,286 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from airflow import DAG, settings
+
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+from sqlalchemy import text
+import boto3
+import botocore
+from airflow.utils.task_group import TaskGroup
+import os
+import csv
+from airflow.models import Variable,Connection
+import json
+
+"""
+This module imports data in to the table from the data exported by the export script
+This iterate through OBJECTS_TO_IMPORT which contains COPY statement and the csv file with data.
+This module also copies a configurabled days of task instance log from Cloud Watch
+
+"""
+# S3 prefix to look for exported data
+S3_KEY = 'data/'
+
+dag_id = 'mwaa_import_data'
+
+DAG_RUN_IMPORT = "COPY \
+dag_run(dag_id, clear_number, execution_date, state, run_id, external_trigger, \
+conf, end_date,start_date, run_type, last_scheduling_decision, \
+dag_hash, creating_job_id, queued_at, data_interval_start, data_interval_end, log_template_id, updated_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+TASK_INSTANCE_IMPORT = "COPY task_instance(task_id, dag_id, run_id, custom_operator_name, start_date, end_date, \
+duration, state, task_display_name, try_number, hostname, unixname, job_id, pool, \
+queue, priority_weight, operator, queued_dttm, rendered_map_index, pid, max_tries, executor_config,\
+pool_slots, queued_by_job_id, external_executor_id, trigger_id , \
+trigger_timeout, next_method, next_kwargs, map_index, executor, updated_at) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+TASK_FAIL_IMPORT = "COPY task_fail(task_id, dag_id, run_id, map_index, \
+ start_date, end_date, duration) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+
+JOB_IMPORT = "COPY JOB(dag_id,  state, job_type , start_date, \
+                end_date, latest_heartbeat, executor_class, hostname, unixname) \
+                FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+
+LOG_IMPORT = "COPY log(dttm, dag_id, task_id, event, execution_date, owner, owner_display_name, run_id, extra, try_number) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+POOL_SLOTS = "COPY slot_pool(pool, slots, description, include_deferred) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+# NOTE: The trigger table is intentionally excluded from import.
+# Starting in Airflow 2.9.0, trigger.kwargs is Fernet-encrypted with a per-environment key.
+# Importing trigger rows from another environment causes cryptography.fernet.InvalidToken
+# errors that crash the triggerer and scheduler. Triggers are ephemeral and are recreated
+# automatically when DAGs with deferrable operators run on the new environment.
+
+# Starting in v2.9.2, we are exculing dataset tables from imports as they are auto-generated
+OBJECTS_TO_IMPORT = [
+    [DAG_RUN_IMPORT, "dag_run.csv"],
+    [LOG_IMPORT, "log.csv"],
+    [JOB_IMPORT, "job.csv"],
+    [POOL_SLOTS, "slot_pool.csv"],
+]
+
+# pause all dags before starting export
+def pause_dags():
+    session = settings.Session()
+    session.execute(text(f"update dag set is_paused = true where dag_id != '{dag_id}';"))
+    session.commit()
+    session.close()
+
+def read_s3(context, filename):
+    resource = boto3.resource('s3')
+    bucket = resource.Bucket(get_s3_bucket(context))
+    tempfile = f"/tmp/{filename}"
+    try:
+        bucket.download_file(S3_KEY + filename, tempfile)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "404":
+            return None
+        else:
+            raise
+    else:
+        return tempfile
+
+
+def activate_dags(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, "active_dags.csv")
+    if (not tempfile):
+        return
+
+    conn = settings.engine.raw_connection()
+    try:
+        session.execute(
+            text(f"create table if not exists active_dags(dag_id varchar(250))"))
+        session.commit()
+        with open(tempfile, 'r') as f:
+            cursor = conn.cursor()
+            cursor.copy_expert(
+                "COPY active_dags FROM STDIN WITH (FORMAT CSV, HEADER TRUE)", f)
+            conn.commit()
+        session.execute(text(
+            f"UPDATE dag d SET is_paused=false FROM active_dags ed WHERE d.dag_id = ed.dag_id;"))
+        session.commit()
+    finally:
+        conn.close()
+
+# Variables are imported separately as they are encyrpted
+def importVariable(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, 'variable.csv')
+    if (not tempfile):
+        return
+
+    with open(tempfile, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        rows = []
+        for row in reader:
+            rowexist = session.query(Variable).filter(Variable.key==row[0]).all()
+            if (len(rowexist)==0):
+                rows.append(Variable(row[0], row[1]))
+            else:
+                print(f"Already Exists Varible {list(rowexist)}")
+        if len(rows) > 0:
+            session.add_all(rows)
+    session.commit()
+    session.close()
+
+
+def importConnection(**context):
+    session = settings.Session()
+    tempfile = read_s3(context, 'connection.csv')
+    if (not tempfile):
+        return
+
+    with open(tempfile, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        rows = []
+        for row in reader:
+            rowexist = session.query(Connection).filter(Connection.conn_id==row[0]).all()
+            if(len(rowexist) == 0):
+                port = 0
+                if(len(row[7]) > 0):
+                    port = int(row[7])
+                rows.append(Connection(row[0], row[1],row[2], row[3],row[4],
+                             row[5],row[6], port,row[8]))
+
+        if len(rows) > 0:
+            session.add_all(rows)
+    session.commit()
+    session.close()
+
+
+def load_data(**context):
+    query = context['query']
+    tempfile = read_s3(context, context['file'])
+    if (not tempfile):
+        return
+
+    conn = settings.engine.raw_connection()
+    try:
+        with open(tempfile, 'r') as f:
+            cursor = conn.cursor()
+            cursor.copy_expert(query, f)
+            conn.commit()
+    finally:
+        conn.close()
+        os.remove(tempfile)
+
+
+# Export Failure/Success notification functions
+def get_s3_bucket(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['bucket']
+
+
+def get_task_token(context):
+    dag_run = context.get('dag_run')
+    return dag_run.conf['taskToken']
+
+
+def get_dag_run_result(context):
+    dag_run = context.get('dag_run')
+    task_instances = dag_run.get_task_instances()
+    task_states = []
+    for task in task_instances:
+        task_states.append(f'{task.task_id} => {task.state}')
+    return {'dag': dag_run.dag_id, 'dag_run': dag_run.run_id, 'tasks': task_states}
+
+
+def notify_success(**context):
+    result = get_dag_run_result(context)
+    result['location'] = f's3://{get_s3_bucket(context)}/{S3_KEY}'
+    result['status'] = 'Success'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_success(taskToken=token, output=json.dumps(result))
+
+
+def notify_failure(context):
+    result = get_dag_run_result(context)
+    result['status'] = 'Fail'
+
+    token = get_task_token(context)
+    sfn = boto3.client('stepfunctions')
+    sfn.send_task_failure(
+        taskToken=token, error='Import Error', cause=json.dumps(result))
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(1),
+    'on_failure_callback': notify_failure
+}
+with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=default_args) as dag:
+
+    pause_dags_t = PythonOperator(
+        task_id="pause_dags",
+        python_callable=pause_dags
+    )
+    with TaskGroup(group_id='toplevel_tables') as import_t:
+        for x in OBJECTS_TO_IMPORT:
+            load_task = PythonOperator(
+                task_id=x[1],
+                python_callable=load_data,
+                op_kwargs={'query': x[0], 'file': x[1]},
+                provide_context=True
+            )
+        load_variable_t = PythonOperator(
+            task_id="variable",
+            python_callable=importVariable,
+            provide_context=True
+        )
+        load_connection_t = PythonOperator(
+            task_id="connection",
+            python_callable=importConnection,
+            provide_context=True
+        )
+
+    pause_dags_t >> import_t
+    load_task_instance = PythonOperator(
+        task_id="load_ti",
+        op_kwargs={'query': TASK_INSTANCE_IMPORT, 'file': 'task_instance.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    import_t >> load_task_instance
+
+    taskfail_dagrun = PythonOperator(
+        task_id="task_fail_run",
+        op_kwargs={'query': TASK_FAIL_IMPORT, 'file': 'task_fail.csv'},
+        python_callable=load_data,
+        provide_context=True
+    )
+    load_task_instance >> taskfail_dagrun
+
+    activate_dags_t = PythonOperator(
+        task_id="activate_dags",
+        python_callable=activate_dags,
+        provide_context=True
+    )
+    load_task_instance >> activate_dags_t
+
+    notify_success_t = PythonOperator(
+        task_id='notify_success',
+        python_callable=notify_success,
+        provide_context=True
+    )
+    activate_dags_t >> notify_success_t
+    taskfail_dagrun >> notify_success_t

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_export_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_export_data.py
@@ -66,7 +66,13 @@ JOB_SELECT = "select dag_id,  state, job_type , start_date, \
 end_date, latest_heartbeat, executor_class, hostname, unixname from job"
 
 POOL_SLOTS = "select pool, slots, description, include_deferred from slot_pool where pool != 'default_pool'"
-TRIGGER = "select classpath, kwargs, created_date, triggerer_id from trigger"
+
+# NOTE: The trigger table is intentionally excluded from export.
+# Starting in Airflow 2.9.0, trigger.kwargs is Fernet-encrypted with a per-environment key.
+# Exporting and importing these rows into a different environment causes
+# cryptography.fernet.InvalidToken errors that crash the triggerer and scheduler.
+# Triggers are ephemeral (in-flight async waits for deferred tasks) and are recreated
+# automatically when DAGs with deferrable operators run on the new environment.
 
 
 ##################
@@ -88,7 +94,6 @@ OBJECTS_TO_EXPORT = [
     [LOG_SELECT, "log"],
     [TASK_FAIL_SELECT, "task_fail"],
     [JOB_SELECT, "job"],
-    [TRIGGER, "trigger"],
     [POOL_SLOTS, "slot_pool"]
 ]
 

--- a/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_import_data.py
+++ b/usecases/start-stop-mwaa-environment/mwaairflow/assets/dags/2.9.2/mwaa_import_data.py
@@ -61,8 +61,12 @@ JOB_IMPORT = "COPY JOB(dag_id,  state, job_type , start_date, \
 
 LOG_IMPORT = "COPY log(dttm, dag_id, task_id, event, execution_date, owner, owner_display_name, run_id, extra) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
 POOL_SLOTS = "COPY slot_pool(pool, slots, description, include_deferred) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
-TRIGGER = "COPY trigger(classpath, kwargs, created_date, triggerer_id)\
-             FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+
+# NOTE: The trigger table is intentionally excluded from import.
+# Starting in Airflow 2.9.0, trigger.kwargs is Fernet-encrypted with a per-environment key.
+# Importing trigger rows from another environment causes cryptography.fernet.InvalidToken
+# errors that crash the triggerer and scheduler. Triggers are ephemeral and are recreated
+# automatically when DAGs with deferrable operators run on the new environment.
 
 # Starting in v2.9.2, we are exculing dataset tables from imports as they are auto-generated
 OBJECTS_TO_IMPORT = [
@@ -256,13 +260,7 @@ with DAG(dag_id=dag_id, schedule_interval=None, catchup=False,  default_args=def
         python_callable=load_data,
         provide_context=True
     )
-    load_triggers = PythonOperator(
-        task_id="load_trg",
-        op_kwargs={'query': TRIGGER, 'file': 'trigger.csv'},
-        python_callable=load_data,
-        provide_context=True
-    )
-    import_t >> load_triggers >> load_task_instance
+    import_t >> load_task_instance
 
     taskfail_dagrun = PythonOperator(
         task_id="task_fail_run",


### PR DESCRIPTION
*Issue # https://github.com/aws-samples/amazon-mwaa-examples/issues/92

*Description of changes:*

Fixes a bug in the start-stop-mwaa-environment example where importing the `trigger` table between environments crashes the triggerer with `cryptography.fernet.InvalidToken`, taking down the scheduler.

Since Airflow 2.9.0, trigger kwargs are Fernet-encrypted per-environment. The export DAG copies raw ciphertext which the destination cannot decrypt. Triggers are ephemeral and recreated automatically - no data is lost by excluding them.

**Changes:**

- Remove trigger table from 2.9.2 export/import DAGs
- Add `2.10.x` DAGs covering MWAA 2.10.1 through 2.11.x
- Document the limitation in README
- Add Disclaimer section to all README.md files
- Add `.aws-sam/` and `data/` to `.gitignore`

**Tested:** End-to-end export + restore on MWAA 2.10.3 and 2.11.0 - all tables restore correctly, no trigger.csv exported, triggerer stable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
